### PR TITLE
call _CrtDumpMemoryLeaks() only under Windows

### DIFF
--- a/audemutest.c
+++ b/audemutest.c
@@ -228,7 +228,7 @@ Exit_AudDeinit:
 	Audio_Deinit();
 	printf("Done.\n");
 	
-#if _DEBUG && defined ( _WIN32)
+#if defined(_DEBUG) && defined(_WIN32)
 	if (_CrtDumpMemoryLeaks())
 		_getch();
 #endif

--- a/audemutest.c
+++ b/audemutest.c
@@ -228,7 +228,7 @@ Exit_AudDeinit:
 	Audio_Deinit();
 	printf("Done.\n");
 	
-#if _DEBUG
+#if _DEBUG && defined ( _WIN32)
 	if (_CrtDumpMemoryLeaks())
 		_getch();
 #endif

--- a/audiotest.c
+++ b/audiotest.c
@@ -214,7 +214,7 @@ Exit_Deinit:
 	Audio_Deinit();
 	printf("Done.\n");
 	
-#if _DEBUG
+#if _DEBUG && defined ( _WIN32)
 	if (_CrtDumpMemoryLeaks())
 		_getch();
 #endif

--- a/audiotest.c
+++ b/audiotest.c
@@ -214,7 +214,7 @@ Exit_Deinit:
 	Audio_Deinit();
 	printf("Done.\n");
 	
-#if _DEBUG && defined ( _WIN32)
+#if defined(_DEBUG) && defined(_WIN32)
 	if (_CrtDumpMemoryLeaks())
 		_getch();
 #endif

--- a/vgmtest.c
+++ b/vgmtest.c
@@ -327,7 +327,7 @@ Exit_AudDeinit:
 	Audio_Deinit();
 	printf("Done.\n");
 	
-#if _DEBUG && defined (_WIN32)
+#if defined(_DEBUG) && defined(_WIN32)
 	if (_CrtDumpMemoryLeaks())
 		_getch();
 #endif

--- a/vgmtest.c
+++ b/vgmtest.c
@@ -327,7 +327,7 @@ Exit_AudDeinit:
 	Audio_Deinit();
 	printf("Done.\n");
 	
-#if _DEBUG
+#if _DEBUG && defined (_WIN32)
 	if (_CrtDumpMemoryLeaks())
 		_getch();
 #endif


### PR DESCRIPTION
Fixes compilation errors with DEBUG = 1 such as 
```
audiotest.c:227: undefined reference to `_CrtDumpMemoryLeaks'
```
on non-Windows operating systems.