### PR TITLE
set a working include path when used as a subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,11 @@
 project(libVgmTest)
 cmake_minimum_required(VERSION 3.1)
 
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/libs/cmake_modules/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/libs/cmake_modules/")
 
 if(MSVC)
 	set(CMAKE_DEBUG_POSTFIX "d")
@@ -22,9 +22,9 @@ if(MSVC)
 	set(CMAKE_MINSIZEREL_POSTFIX "_${MSVC_POSTFIX}${CMAKE_MINSIZEREL_POSTFIX}")
 	set(CMAKE_RELWITHDEBINFO_POSTFIX "_${MSVC_POSTFIX}${CMAKE_RELWITHDEBINFO_POSTFIX}")
 	
-	set(ZLIB_ROOT "${CMAKE_SOURCE_DIR}/libs" CACHE PATH "ZLib directory")
-	set(Iconv_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/libs/iconv/include" CACHE PATH "directory with iconv headers")
-	set(Iconv_LIBRARY "${CMAKE_SOURCE_DIR}/libs/iconv/lib/libiconv.lib" CACHE FILEPATH "iconv library")
+	set(ZLIB_ROOT "${PROJECT_SOURCE_DIR}/libs" CACHE PATH "ZLib directory")
+	set(Iconv_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/libs/iconv/include" CACHE PATH "directory with iconv headers")
+	set(Iconv_LIBRARY "${PROJECT_SOURCE_DIR}/libs/iconv/lib/libiconv.lib" CACHE FILEPATH "iconv library")
 	
 	if(NOT MSVC_VERSION LESS 1400)
 		add_definitions("/D _CRT_SECURE_NO_WARNINGS")
@@ -88,24 +88,24 @@ endif()
 if(BUILD_TESTS)
 
 add_executable(audiotest audiotest.c)
-target_include_directories(audiotest PRIVATE ${CMAKE_SOURCE_DIR})
+target_include_directories(audiotest PRIVATE ${PROJECT_SOURCE_DIR})
 target_link_libraries(audiotest PRIVATE vgm-audio)
 add_sanitizers(audiotest)
 
 add_executable(emutest emutest.c)
-target_include_directories(emutest PRIVATE ${CMAKE_SOURCE_DIR})
+target_include_directories(emutest PRIVATE ${PROJECT_SOURCE_DIR})
 target_link_libraries(emutest PRIVATE vgm-emu)
 add_sanitizers(emutest)
 
 add_executable(audemutest audemutest.c)
-target_include_directories(audemutest PRIVATE ${CMAKE_SOURCE_DIR})
+target_include_directories(audemutest PRIVATE ${PROJECT_SOURCE_DIR})
 target_link_libraries(audemutest PRIVATE vgm-audio vgm-emu)
 add_sanitizers(audemutest)
 
 find_package(ZLIB REQUIRED)
 
 add_executable(vgmtest vgmtest.c player/dblk_compr.c)
-target_include_directories(vgmtest PRIVATE ${CMAKE_SOURCE_DIR})
+target_include_directories(vgmtest PRIVATE ${PROJECT_SOURCE_DIR})
 target_link_libraries(vgmtest PRIVATE ZLIB::ZLIB vgm-audio vgm-emu)
 add_sanitizers(vgmtest)
 
@@ -113,7 +113,7 @@ endif(BUILD_TESTS)
 
 if(BUILD_PLAYER)
 add_executable(player player.cpp player/dblk_compr.c)
-target_include_directories(player PRIVATE ${CMAKE_SOURCE_DIR})
+target_include_directories(player PRIVATE ${PROJECT_SOURCE_DIR})
 target_link_libraries(player PRIVATE vgm-audio vgm-player)
 add_sanitizers(player)
 endif()

--- a/audio/CMakeLists.txt
+++ b/audio/CMakeLists.txt
@@ -2,6 +2,8 @@
 project(vgm-audio)
 cmake_minimum_required(VERSION 2.8)
 
+set(LIBVGM_SOURCE_DIR ${PROJECT_SOURCE_DIR}/..)
+
 set(AUDIO_DEFS)
 set(AUDIO_FILES
 	AudioStream.c
@@ -123,21 +125,21 @@ set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 target_compile_definitions(${PROJECT_NAME} PUBLIC ${AUDIO_DEFS})
 
-target_include_directories(${PROJECT_NAME} PRIVATE
-	${CMAKE_SOURCE_DIR}
-	${CMAKE_SOURCE_DIR}/libs/include
+target_include_directories(${PROJECT_NAME}
+	PUBLIC ${LIBVGM_SOURCE_DIR}
+	PRIVATE ${LIBVGM_SOURCE_DIR}/libs/include
 )
 if(WIN32 AND NOT MSVC)
 	target_include_directories(${PROJECT_NAME} PRIVATE
-		${CMAKE_SOURCE_DIR}/libs/include_mingw
+		${LIBVGM_SOURCE_DIR}/libs/include_mingw
 	)
 elseif(MSVC)
 	target_include_directories(${PROJECT_NAME} PRIVATE
-		${CMAKE_SOURCE_DIR}/libs/include_vc
+		${LIBVGM_SOURCE_DIR}/libs/include_vc
 	)
 	if(MSVC_VERSION LESS 1400)
 		target_include_directories(${PROJECT_NAME} PRIVATE
-			${CMAKE_SOURCE_DIR}/libs/include_vc6
+			${LIBVGM_SOURCE_DIR}/libs/include_vc6
 		)
 	endif()
 endif()

--- a/emu/CMakeLists.txt
+++ b/emu/CMakeLists.txt
@@ -2,6 +2,7 @@
 project(vgm-emu)
 cmake_minimum_required(VERSION 2.8)
 
+set(LIBVGM_SOURCE_DIR ${PROJECT_SOURCE_DIR}/..)
 
 # Note: If multiple cores are present for a device, the core chosed by default is marked with *.
 
@@ -577,11 +578,10 @@ set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 target_compile_definitions(${PROJECT_NAME} PUBLIC ${EMU_DEFS})
 
-target_include_directories(${PROJECT_NAME} PRIVATE
-	${CMAKE_SOURCE_DIR}
-	${CMAKE_SOURCE_DIR}/libs/include
+target_include_directories(${PROJECT_NAME}
+	PUBLIC ${LIBVGM_SOURCE_DIR}
+	PRIVATE ${LIBVGM_SOURCE_DIR}/libs/include
 )
-target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_SOURCE_DIR})
 
 if(CMAKE_COMPILER_IS_GNUCC OR UNIX)
 	# link Math library

--- a/player/CMakeLists.txt
+++ b/player/CMakeLists.txt
@@ -2,6 +2,8 @@
 project(vgm-player)
 cmake_minimum_required(VERSION 2.8)
 
+set(LIBVGM_SOURCE_DIR ${PROJECT_SOURCE_DIR}/..)
+
 set(PLAYER_DEFS)
 set(PLAYER_FILES
 	dblk_compr.c
@@ -29,21 +31,21 @@ set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 target_compile_definitions(${PROJECT_NAME} PUBLIC ${PLAYER_DEFS})
 
-target_include_directories(${PROJECT_NAME} PRIVATE
-	${CMAKE_SOURCE_DIR}
-	${CMAKE_SOURCE_DIR}/libs/include
+target_include_directories(${PROJECT_NAME}
+	PUBLIC ${LIBVGM_SOURCE_DIR}
+	PRIVATE ${LIBVGM_SOURCE_DIR}/libs/include
 )
 if(WIN32 AND NOT MSVC)
 	target_include_directories(${PROJECT_NAME} PRIVATE
-		${CMAKE_SOURCE_DIR}/libs/include_mingw
+		${LIBVGM_SOURCE_DIR}/libs/include_mingw
 	)
 elseif(MSVC)
 	target_include_directories(${PROJECT_NAME} PRIVATE
-		${CMAKE_SOURCE_DIR}/libs/include_vc
+		${LIBVGM_SOURCE_DIR}/libs/include_vc
 	)
 	if(MSVC_VERSION LESS 1400)
 		target_include_directories(${PROJECT_NAME} PRIVATE
-			${CMAKE_SOURCE_DIR}/libs/include_vc6
+			${LIBVGM_SOURCE_DIR}/libs/include_vc6
 		)
 	endif()
 endif()

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -2,6 +2,8 @@
 project(vgm-utils)
 cmake_minimum_required(VERSION 3.1)
 
+set(LIBVGM_SOURCE_DIR ${PROJECT_SOURCE_DIR}/..)
+
 set(UTIL_DEFS)
 set(UTIL_FILES)
 # export headers
@@ -76,20 +78,20 @@ set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_compile_definitions(${PROJECT_NAME} PUBLIC ${UTIL_DEFS})
 
 target_include_directories(${PROJECT_NAME} PRIVATE
-	${CMAKE_SOURCE_DIR}
-	${CMAKE_SOURCE_DIR}/libs/include
+	PUBLIC ${LIBVGM_SOURCE_DIR}
+	PRIVATE ${LIBVGM_SOURCE_DIR}/libs/include
 )
 if(WIN32 AND NOT MSVC)
 	target_include_directories(${PROJECT_NAME} PRIVATE
-		${CMAKE_SOURCE_DIR}/libs/include_mingw
+		${LIBVGM_SOURCE_DIR}/libs/include_mingw
 	)
 elseif(MSVC)
 	target_include_directories(${PROJECT_NAME} PRIVATE
-		${CMAKE_SOURCE_DIR}/libs/include_vc
+		${LIBVGM_SOURCE_DIR}/libs/include_vc
 	)
 	if(MSVC_VERSION LESS 1400)
 		target_include_directories(${PROJECT_NAME} PRIVATE
-			${CMAKE_SOURCE_DIR}/libs/include_vc6
+			${LIBVGM_SOURCE_DIR}/libs/include_vc6
 		)
 	endif()
 endif()


### PR DESCRIPTION
The library cannot be currently added into a project by `add_subdirectory`.
The header path will be incorrect, because the `SOURCE_DIR` will be substituted with the path of the root project instead of libvgm.

Also, the include path to libary headers is not going to be inherited when it's linked.
To fix this, I have modified the visibility to `PUBLIC`.