### PR TITLE
Get track information as array of Vorbis-style tags

### DIFF
--- a/player.cpp
+++ b/player.cpp
@@ -150,24 +150,18 @@ int main(int argc, char* argv[])
 	{
 		S98Player* s98play = dynamic_cast<S98Player*>(player);
 		const S98_HEADER* s98hdr = s98play->GetFileHeader();
-		const char* s98Title = player->GetSongTitle();
 		
 		printf("S98 v%u, Total Length: %.2f s, Loop Length: %.2f s, Tick Rate: %u/%u", s98hdr->fileVer,
 				player->Tick2Second(player->GetTotalTicks()), player->Tick2Second(player->GetLoopTicks()),
 				s98hdr->tickMult, s98hdr->tickDiv);
-		if (s98Title != NULL)
-			printf("\nSong Title: %s", s98Title);
 	}
 	else if (player->GetPlayerType() == FCC_VGM)
 	{
 		VGMPlayer* vgmplay = dynamic_cast<VGMPlayer*>(player);
 		const VGM_HEADER* vgmhdr = vgmplay->GetFileHeader();
-		const char* vgmTitle = player->GetSongTitle();
 		
 		printf("VGM v%3X, Total Length: %.2f s, Loop Length: %.2f s", vgmhdr->fileVer,
 				player->Tick2Second(player->GetTotalTicks()), player->Tick2Second(player->GetLoopTicks()));
-		if (vgmTitle != NULL && strlen(vgmTitle) > 0)
-			printf("\nSong Title: %s", vgmTitle);
 	}
 	else if (player->GetPlayerType() == FCC_DRO)
 	{
@@ -186,6 +180,44 @@ int main(int argc, char* argv[])
 		printf("DRO v%u, Total Length: %.2f s, HW Type: %s", drohdr->verMajor,
 				player->Tick2Second(player->GetTotalTicks()), hwType);
 	}
+	
+	const char* songTitle = NULL;
+	const char* songAuthor = NULL;
+	const char* songGame = NULL;
+	const char* songSystem = NULL;
+	const char* songDate = NULL;
+	const char* songComment = NULL;
+	
+	const char* const* tagList = player->GetSongTags();
+	for (const char* const* t = tagList; *t; t += 2)
+	{
+		if (!strcmp(t[0], "TITLE"))
+			songTitle = t[1];
+		else if (!strcmp(t[0], "ARTIST"))
+			songAuthor = t[1];
+		else if (!strcmp(t[0], "GAME"))
+			songGame = t[1];
+		else if (!strcmp(t[0], "SYSTEM"))
+			songSystem = t[1];
+		else if (!strcmp(t[0], "DATE"))
+			songDate = t[1];
+		else if (!strcmp(t[0], "COMMENT"))
+			songComment = t[1];
+	}
+	
+	if (songTitle != NULL && songTitle[0] != '\0')
+		printf("\nSong Title: %s", songTitle);
+	if (songAuthor != NULL && songAuthor[0] != '\0')
+		printf("\nSong Author: %s", songAuthor);
+	if (songGame != NULL && songGame[0] != '\0')
+		printf("\nSong Game: %s", songGame);
+	if (songSystem != NULL && songSystem[0] != '\0')
+		printf("\nSong System: %s", songSystem);
+	if (songDate != NULL && songDate[0] != '\0')
+		printf("\nSong Date: %s", songDate);
+	if (songComment != NULL && songComment[0] != '\0')
+		printf("\nSong Comment: %s", songComment);
+	
 	putchar('\n');
 	
 	player->SetSampleRate(sampleRate);

--- a/player/droplayer.cpp
+++ b/player/droplayer.cpp
@@ -320,6 +320,12 @@ const char* DROPlayer::GetSongTitle(void)
 	return NULL;
 }
 
+const char* const* DROPlayer::GetSongTags(void)
+{
+	static const char* const tagList[] = { NULL };
+	return tagList;
+}
+
 UINT8 DROPlayer::SetSampleRate(UINT32 sampleRate)
 {
 	if (_playState & PLAYSTATE_PLAY)

--- a/player/droplayer.hpp
+++ b/player/droplayer.hpp
@@ -78,6 +78,7 @@ public:
 	UINT8 UnloadFile(void);
 	const DRO_HEADER* GetFileHeader(void) const;
 	const char* GetSongTitle(void);
+	const char* const* GetSongTags(void);
 	
 	//UINT32 GetSampleRate(void) const;
 	UINT8 SetSampleRate(UINT32 sampleRate);

--- a/player/playerbase.hpp
+++ b/player/playerbase.hpp
@@ -36,6 +36,7 @@ public:
 	virtual UINT8 LoadFile(DATA_LOADER *dataLoader) = 0;
 	virtual UINT8 UnloadFile(void) = 0;
 	virtual const char* GetSongTitle(void) = 0;
+	virtual const char* const* GetSongTags(void) = 0;
 	
 	virtual UINT32 GetSampleRate(void) const;
 	virtual UINT8 SetSampleRate(UINT32 sampleRate);

--- a/player/s98player.hpp
+++ b/player/s98player.hpp
@@ -53,6 +53,7 @@ public:
 	UINT8 UnloadFile(void);
 	const S98_HEADER* GetFileHeader(void) const;
 	const char* GetSongTitle(void);
+	const char* const* GetSongTags(void);
 	
 	//UINT32 GetSampleRate(void) const;
 	UINT8 SetSampleRate(UINT32 sampleRate);
@@ -99,6 +100,7 @@ private:
 	UINT32 _totalTicks;
 	UINT32 _loopTick;
 	std::map<std::string, std::string> _tagData;
+	std::vector<const char*> _tagList;
 	
 	//UINT32 _outSmplRate;
 	

--- a/player/vgmplayer.hpp
+++ b/player/vgmplayer.hpp
@@ -121,6 +121,7 @@ public:
 	UINT8 UnloadFile(void);
 	const VGM_HEADER* GetFileHeader(void) const;
 	const char* GetSongTitle(void);
+	const char* const* GetSongTags(void);
 	
 	//UINT32 GetSampleRate(void) const;
 	UINT8 SetSampleRate(UINT32 sampleRate);
@@ -231,7 +232,24 @@ protected:
 	UINT8 _hdrBuffer[_HDR_BUF_SIZE];	// buffer containing the file header
 	UINT32 _hdrLenFile;
 	UINT32 _tagVer;
-	std::vector<std::string> _tagData;
+	
+	enum
+	{
+		_TAG_TRACK_NAME_EN,
+		_TAG_TRACK_NAME_JP,
+		_TAG_GAME_NAME_EN,
+		_TAG_GAME_NAME_JP,
+		_TAG_SYSTEM_NAME_EN,
+		_TAG_SYSTEM_NAME_JP,
+		_TAG_ARTIST_EN,
+		_TAG_ARTIST_JP,
+		_TAG_GAME_RELEASE_DATE,
+		_TAG_VGM_CREATOR,
+		_TAG_NOTES,
+		_TAG_COUNT,
+	};
+	std::string _tagData[_TAG_COUNT];
+	const char* _tagList[2 * _TAG_COUNT + 1];
 	
 	//UINT32 _outSmplRate;
 	


### PR DESCRIPTION
In replacement of PR #17, following suggestions of @superctr and @jprjr

It provides access to tags as an array of string pairs with a NULL terminator.

**Tag specification**
- [Vorbis](https://sno.phy.queensu.ca/~phil/exiftool/TagNames/Vorbis.html) as suggested: "TITLE", "ARTIST", "DATE", "ENCODED_BY", "COMMENT", "GENRE", "COPYRIGHT"
- `GAME` and `SYSTEM` tags which are not part of the specification
- for multi-language tags I have used a notation such as "TITLE-JPN"
  I imitated an ID3 feature documented [here](https://sno.phy.queensu.ca/~phil/exiftool/TagNames/ID3.html) which reads:
`ID3v2 tags which support multiple languages (eg. Comment and Lyrics) are extracted by specifying the tag name, followed by a dash ('-'), then a 3-character ISO 639-2 language code (eg. "Comment-spa").`
I have upcased the language code.

I know little of common practice regarding tag and conventions, please correct any mistake.