### PR TITLE
fix memory access issues due to misalignment

### DIFF
--- a/player/vgmplayer.cpp
+++ b/player/vgmplayer.cpp
@@ -69,22 +69,14 @@
 INLINE UINT16 ReadLE16(const UINT8* data)
 {
 	// read 16-Bit Word (Little Endian/Intel Byte Order)
-#ifdef VGM_LITTLE_ENDIAN
-	return *(UINT16*)data;
-#else
 	return (data[0x01] << 8) | (data[0x00] << 0);
-#endif
 }
 
 INLINE UINT32 ReadLE32(const UINT8* data)
 {
 	// read 32-Bit Word (Little Endian/Intel Byte Order)
-#ifdef VGM_LITTLE_ENDIAN
-	return	*(UINT32*)data;
-#else
 	return	(data[0x03] << 24) | (data[0x02] << 16) |
 			(data[0x01] <<  8) | (data[0x00] <<  0);
-#endif
 }
 
 INLINE UINT32 ReadRelOfs(const UINT8* data, UINT32 fileOfs)

--- a/player/vgmplayer_cmdhandler.cpp
+++ b/player/vgmplayer_cmdhandler.cpp
@@ -488,42 +488,26 @@
 INLINE UINT16 ReadLE16(const UINT8* data)
 {
 	// read 16-Bit Word (Little Endian/Intel Byte Order)
-#ifdef VGM_LITTLE_ENDIAN
-	return *(UINT16*)data;
-#else
 	return (data[0x01] << 8) | (data[0x00] << 0);
-#endif
 }
 
 INLINE UINT16 ReadBE16(const UINT8* data)
 {
 	// read 16-Bit Word (Big Endian/Motorola Byte Order)
-#ifdef VGM_BIG_ENDIAN
-	return *(UINT16*)data;
-#else
 	return (data[0x00] << 8) | (data[0x01] << 0);
-#endif
 }
 
 INLINE UINT32 ReadLE24(const UINT8* data)
 {
 	// read 24-Bit Word (Little Endian/Intel Byte Order)
-#ifdef VGM_LITTLE_ENDIAN
-	return	(*(UINT32*)data) & 0x00FFFFFF;
-#else
 	return	(data[0x02] << 16) | (data[0x01] <<  8) | (data[0x00] <<  0);
-#endif
 }
 
 INLINE UINT32 ReadLE32(const UINT8* data)
 {
 	// read 32-Bit Word (Little Endian/Intel Byte Order)
-#ifdef VGM_LITTLE_ENDIAN
-	return	*(UINT32*)data;
-#else
 	return	(data[0x03] << 24) | (data[0x02] << 16) |
 			(data[0x01] <<  8) | (data[0x00] <<  0);
-#endif
 }
 
 void VGMPlayer::Cmd_invalid(void)


### PR DESCRIPTION
#23

I have corrected some alignment problems, as reported by @vampirefrog.
I have looked in sources for the other locations of endian-dependent reads and fixed as well.

At least on GCC amd64, the special case removed is not useful, because assembly output is identical.

Regarding the affected platform wasm, I haven't tried because I don't have familiarity with it.
