### PR TITLE
fix a compilation error on gcc

### DIFF
--- a/player/s98player.cpp
+++ b/player/s98player.cpp
@@ -307,7 +307,7 @@ UINT8 S98Player::LoadTags(void)
 		std::transform(curKey.begin(), curKey.end(), curKey.begin(), ::toupper);
 		
 		const char *tagName = NULL;
-		for (const char* const* t = S98_TAG_MAPPING; *t != '\0'; t += 2)
+		for (const char* const* t = S98_TAG_MAPPING; *t != NULL; t += 2)
 		{
 			if (curKey == t[0])
 			{


### PR DESCRIPTION
It fixes this error:
`s98player.cpp:310:54: error: ISO C++ forbids comparison between pointer and integer [-fpermissive]`
