### PR TITLE
emu2413: remove custom INLINE def (brought in via snddef include)

### DIFF
--- a/emu/cores/emu2413.c
+++ b/emu/cores/emu2413.c
@@ -15,16 +15,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifndef INLINE
-#if defined(_MSC_VER)
-#define INLINE __inline
-#elif defined(__GNUC__)
-#define INLINE __inline__
-#else
-#define INLINE inline
-#endif
-#endif
-
 #include <stdtype.h>
 #include "../snddef.h"
 #include "../EmuStructs.h"


### PR DESCRIPTION
On clang on OSX, emu2413 was generating an undefined symbol for `INIT_DEVINT` since `INLINE` didn't include `static`

This removes it since a few lines below, `#include "../snddef.h"` winds up bringing in the shared `INLINE` definition.