### PR TITLE
install target: place headers into a "vgm" directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,3 +123,11 @@ target_include_directories(player PRIVATE ${PROJECT_SOURCE_DIR})
 target_link_libraries(player PRIVATE vgm-audio vgm-player)
 add_sanitizers(player)
 endif()
+
+set(COMMON_HEADERS
+	common_def.h
+	stdbool.h
+	stdtype.h
+)
+
+install(FILES ${COMMON_HEADERS} DESTINATION include/vgm)

--- a/audio/CMakeLists.txt
+++ b/audio/CMakeLists.txt
@@ -162,4 +162,4 @@ install(TARGETS ${PROJECT_NAME}
 		LIBRARY DESTINATION "lib"
 		ARCHIVE DESTINATION "lib"
 		)
-install(FILES ${AUDIO_HEADERS} DESTINATION include/audio)
+install(FILES ${AUDIO_HEADERS} DESTINATION include/vgm/audio)

--- a/emu/CMakeLists.txt
+++ b/emu/CMakeLists.txt
@@ -599,5 +599,5 @@ install(TARGETS ${PROJECT_NAME}
 		LIBRARY DESTINATION "lib"
 		ARCHIVE DESTINATION "lib"
 		)
-install(FILES ${EMU_HEADERS} DESTINATION include/emu)
-install(FILES ${EMU_CORE_HEADERS} DESTINATION include/emu/cores)
+install(FILES ${EMU_HEADERS} DESTINATION include/vgm/emu)
+install(FILES ${EMU_CORE_HEADERS} DESTINATION include/vgm/emu/cores)

--- a/player/CMakeLists.txt
+++ b/player/CMakeLists.txt
@@ -58,4 +58,4 @@ install(TARGETS ${PROJECT_NAME}
 		LIBRARY DESTINATION "lib"
 		ARCHIVE DESTINATION "lib"
 		)
-install(FILES ${PLAYER_HEADERS} DESTINATION include/player)
+install(FILES ${PLAYER_HEADERS} DESTINATION include/vgm/player)

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -109,4 +109,4 @@ install(TARGETS ${PROJECT_NAME}
 		LIBRARY DESTINATION "lib"
 		ARCHIVE DESTINATION "lib"
 		)
-install(FILES ${UTIL_HEADERS} DESTINATION include/utils)
+install(FILES ${UTIL_HEADERS} DESTINATION include/vgm/utils)


### PR DESCRIPTION
By default on linux/unix, doing a `make install` after building creates a directory layout like:

`/usr/local/include/utils/DataLoader.h`

This just places everything into a `vgm` directory, like

`/usr/local/include/vgm/utils/DataLoader.h`

That way it's obvious where/what these headers are for, just based on the filename. Plus it makes them more inline with the library naming (`vgm-utils` => `vgm/utils`, `vgm-player` => `vgm/player`, etc).