### PR TITLE
Use relative includes for all local headers

### DIFF
--- a/audemutest.c
+++ b/audemutest.c
@@ -18,7 +18,7 @@ int __cdecl _getch(void);	// from conio.h
 #define	Sleep(msec)	usleep(msec * 1000)
 #endif
 
-#include <common_def.h>
+#include "common_def.h"
 #include "audio/AudioStream.h"
 #include "audio/AudioStream_SpcDrvFuns.h"
 #include "emu/EmuStructs.h"

--- a/audio/AudDrv_ALSA.c
+++ b/audio/AudDrv_ALSA.c
@@ -10,7 +10,7 @@
 #include <unistd.h>		// for usleep()
 #define	Sleep(msec)	usleep(msec * 1000)
 
-#include <stdtype.h>
+#include "../stdtype.h"
 
 #include "AudioStream.h"
 #include "../utils/OSThread.h"

--- a/audio/AudDrv_CoreAudio.c
+++ b/audio/AudDrv_CoreAudio.c
@@ -10,7 +10,7 @@
 #include <unistd.h>		// for usleep()
 #define	Sleep(msec)	usleep(msec * 1000)
 
-#include <stdtype.h>
+#include "../stdtype.h"
 
 #include "AudioStream.h"
 #include "../utils/OSMutex.h"

--- a/audio/AudDrv_DSound.cpp
+++ b/audio/AudDrv_DSound.cpp
@@ -11,7 +11,7 @@
 #include <dsound.h>
 #include <mmsystem.h>	// for WAVEFORMATEX
 
-#include <stdtype.h>
+#include "../stdtype.h"
 
 #include "AudioStream.h"
 #include "../utils/OSThread.h"

--- a/audio/AudDrv_OSS.c
+++ b/audio/AudDrv_OSS.c
@@ -15,7 +15,7 @@
 #define	Sleep(msec)	usleep(msec * 1000)
 #endif
 
-#include <stdtype.h>
+#include "../stdtype.h"
 
 #include "AudioStream.h"
 #include "../utils/OSThread.h"

--- a/audio/AudDrv_Pulse.c
+++ b/audio/AudDrv_Pulse.c
@@ -10,7 +10,7 @@
 #include <unistd.h>		// for usleep()
 #define	Sleep(msec)	usleep(msec * 1000)
 
-#include <stdtype.h>
+#include "../stdtype.h"
 
 #include "AudioStream.h"
 #include "../utils/OSThread.h"

--- a/audio/AudDrv_SADA.c
+++ b/audio/AudDrv_SADA.c
@@ -14,7 +14,7 @@
 #define	Sleep(msec)	usleep(msec * 1000)
 #endif
 
-#include <stdtype.h>
+#include "../stdtype.h"
 
 #include "AudioStream.h"
 #include "../utils/OSThread.h"

--- a/audio/AudDrv_WASAPI.cpp
+++ b/audio/AudDrv_WASAPI.cpp
@@ -18,7 +18,7 @@
 #define	wcsdup	_wcsdup
 #endif
 
-#include <stdtype.h>
+#include "../stdtype.h"
 
 #include "AudioStream.h"
 #include "../utils/OSThread.h"

--- a/audio/AudDrv_WaveWriter.c
+++ b/audio/AudDrv_WaveWriter.c
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include <string.h>	// for memcpy() etc.
 
-#include <common_def.h>	// stdtype.h, INLINE
+#include "../common_def.h"	// stdtype.h, INLINE
 
 #include "AudioStream.h"
 

--- a/audio/AudDrv_WinMM.c
+++ b/audio/AudDrv_WinMM.c
@@ -7,7 +7,7 @@
 #include <windows.h>
 #include <mmsystem.h>
 
-#include <stdtype.h>
+#include "../stdtype.h"
 
 #include "AudioStream.h"
 #include "../utils/OSThread.h"

--- a/audio/AudDrv_XAudio2.cpp
+++ b/audio/AudDrv_XAudio2.cpp
@@ -15,7 +15,7 @@
 #include <xaudio2.h>
 #include <mmsystem.h>	// for WAVEFORMATEX
 
-#include <stdtype.h>
+#include "../stdtype.h"
 
 #include "AudioStream.h"
 #include "../utils/OSThread.h"

--- a/audio/AudDrv_libao.c
+++ b/audio/AudDrv_libao.c
@@ -10,7 +10,7 @@
 #include <unistd.h>		// for usleep()
 #define	Sleep(msec)	usleep(msec * 1000)
 
-#include <stdtype.h>
+#include "../stdtype.h"
 
 #include "AudioStream.h"
 #include "../utils/OSThread.h"

--- a/audio/AudioStream.c
+++ b/audio/AudioStream.c
@@ -4,8 +4,8 @@
 #include <stdlib.h>
 //#include <string.h>	// for memset
 
-#include <stdtype.h>
-#include <stdbool.h>
+#include "../stdtype.h"
+#include "../stdbool.h"
 
 #include "AudioStream.h"
 #include "../utils/OSMutex.h"

--- a/audio/AudioStructs.h
+++ b/audio/AudioStructs.h
@@ -6,7 +6,7 @@ extern "C"
 {
 #endif
 
-#include <stdtype.h>
+#include "../stdtype.h"
 
 typedef struct _audio_options
 {

--- a/audiotest.c
+++ b/audiotest.c
@@ -16,7 +16,7 @@ int __cdecl _getch(void);	// from conio.h
 #define _getch	getchar
 #endif
 
-#include <common_def.h>
+#include "common_def.h"
 #include "audio/AudioStream.h"
 #include "audio/AudioStream_SpcDrvFuns.h"
 

--- a/emu/EmuStructs.h
+++ b/emu/EmuStructs.h
@@ -7,7 +7,7 @@ extern "C"
 #endif
 
 #include <stddef.h>	// for NULL
-#include <stdtype.h>
+#include "../stdtype.h"
 #include "snddef.h"
 
 typedef struct _device_definition DEV_DEF;

--- a/emu/Resampler.c
+++ b/emu/Resampler.c
@@ -1,7 +1,7 @@
 #include <stddef.h>
 #include <stdlib.h>	// for malloc/free
 
-#include <stdtype.h>
+#include "../stdtype.h"
 #include "EmuStructs.h"
 #include "Resampler.h"
 

--- a/emu/Resampler.h
+++ b/emu/Resampler.h
@@ -6,7 +6,7 @@ extern "C"
 {
 #endif
 
-#include <stdtype.h>
+#include "../stdtype.h"
 #include "snddef.h"	// for DEV_SMPL
 #include "EmuStructs.h"
 

--- a/emu/SoundEmu.c
+++ b/emu/SoundEmu.c
@@ -1,7 +1,7 @@
 #include <stddef.h>
 #include <stdlib.h>	// for malloc/free
 
-#include <stdtype.h>
+#include "../stdtype.h"
 #include "EmuStructs.h"
 #include "SoundEmu.h"
 #include "SoundDevs.h"

--- a/emu/SoundEmu.h
+++ b/emu/SoundEmu.h
@@ -6,7 +6,7 @@ extern "C"
 {
 #endif
 
-#include <stdtype.h>
+#include "../stdtype.h"
 #include "EmuStructs.h"
 
 /**

--- a/emu/cores/2612intf.c
+++ b/emu/cores/2612intf.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../EmuHelper.h"

--- a/emu/cores/262intf.c
+++ b/emu/cores/262intf.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../EmuHelper.h"

--- a/emu/cores/Ootake_PSG.c
+++ b/emu/cores/Ootake_PSG.c
@@ -53,7 +53,7 @@ Copyright(C)2006-2017 Kitao Nakamura.
 #include <string.h>	// for memset
 #include <math.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"

--- a/emu/cores/Ootake_PSG_private.h
+++ b/emu/cores/Ootake_PSG_private.h
@@ -21,7 +21,7 @@
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 **---------------------------------------------------------------------------*/
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 
 static UINT8 device_start_c6280_ootake(const DEV_GEN_CFG* cfg, DEV_INFO* retDevInf);

--- a/emu/cores/adlibemu.h
+++ b/emu/cores/adlibemu.h
@@ -1,7 +1,7 @@
 #ifndef __ADLIBEMU_H__
 #define __ADLIBEMU_H__
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 
 #if defined(OPLTYPE_IS_OPL2)

--- a/emu/cores/adlibemu_opl_inc.c
+++ b/emu/cores/adlibemu_opl_inc.c
@@ -35,7 +35,7 @@
 #include <stdlib.h> // rand
 #include <string.h> // for memset
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "adlibemu_opl_inc.h"
 

--- a/emu/cores/adlibemu_opl_inc.h
+++ b/emu/cores/adlibemu_opl_inc.h
@@ -30,7 +30,7 @@
 /*
 	define Bits, Bitu, Bit32s, Bit32u, Bit16s, Bit16u, Bit8s, Bit8u here
 */
-#include <common_def.h>
+#include "../../common_def.h"
 typedef UINT32		Bitu;
 typedef INT32		Bits;
 typedef UINT32		Bit32u;

--- a/emu/cores/ay8910.c
+++ b/emu/cores/ay8910.c
@@ -537,7 +537,7 @@ YM2203 Japanese datasheet contents, translated: http://www.larwe.com/technical/c
 #include <stdio.h>
 #include <math.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"

--- a/emu/cores/ay8910.h
+++ b/emu/cores/ay8910.h
@@ -1,7 +1,7 @@
 #ifndef __AY8910_H__
 #define __AY8910_H__
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "../EmuStructs.h"
 

--- a/emu/cores/c140.c
+++ b/emu/cores/c140.c
@@ -24,7 +24,7 @@ TODO: What does the INT0 pin do? Normally Namco tied it to VOL0 (with VOL1 = VCC
 #include <string.h>	// for memset
 #include <stddef.h>	// for NULL
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../snddef.h"

--- a/emu/cores/c219.c
+++ b/emu/cores/c219.c
@@ -50,7 +50,7 @@ Unmapped registers:
 #include <string.h>	// for memset
 #include <stddef.h>	// for NULL
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../snddef.h"

--- a/emu/cores/c352.c
+++ b/emu/cores/c352.c
@@ -21,7 +21,7 @@
 #include <string.h>	// for memset
 #include <stddef.h>	// for NULL
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../snddef.h"

--- a/emu/cores/c6280_mame.c
+++ b/emu/cores/c6280_mame.c
@@ -42,7 +42,7 @@
 #include <string.h>	// for memset()
 #include <math.h>	// for pow()
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"

--- a/emu/cores/emu2149.c
+++ b/emu/cores/emu2149.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"

--- a/emu/cores/emu2149_private.h
+++ b/emu/cores/emu2149_private.h
@@ -2,7 +2,7 @@
 #ifndef __EMU2149_H_PRIVATE__
 #define __EMU2149_H_PRIVATE__
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "emutypes.h"
 

--- a/emu/cores/emu2413.c
+++ b/emu/cores/emu2413.c
@@ -25,7 +25,7 @@
 #endif
 #endif
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "emutypes.h"
 #include "../snddef.h"
 #include "../EmuStructs.h"

--- a/emu/cores/emutypes.h
+++ b/emu/cores/emutypes.h
@@ -6,7 +6,7 @@
 #ifdef HAVE_STDINT_H
 #include <stdint.h>
 #else
-#include <stdtype.h>
+#include "../../stdtype.h"
 
 #define __int8_t_defined
 typedef UINT8 uint8_t;

--- a/emu/cores/es5503.c
+++ b/emu/cores/es5503.c
@@ -35,7 +35,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../snddef.h"

--- a/emu/cores/es5506.c
+++ b/emu/cores/es5506.c
@@ -1,6 +1,6 @@
 #include <stddef.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../EmuStructs.h"
 #include "es5506.h"
 

--- a/emu/cores/fmopl.c
+++ b/emu/cores/fmopl.c
@@ -78,7 +78,7 @@ Revision History:
 #define _USE_MATH_DEFINES
 #include <math.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "../EmuHelper.h"
 

--- a/emu/cores/fmopl.h
+++ b/emu/cores/fmopl.h
@@ -1,7 +1,7 @@
 #ifndef __FMOPL_H__
 #define __FMOPL_H__
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 
 /* --- select emulation chips --- */

--- a/emu/cores/fmopn.c
+++ b/emu/cores/fmopn.c
@@ -119,7 +119,7 @@
 #define _USE_MATH_DEFINES
 #include <math.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "../EmuHelper.h"
 

--- a/emu/cores/fmopn.h
+++ b/emu/cores/fmopn.h
@@ -1,7 +1,7 @@
 #ifndef __FMOPN_H__
 #define __FMOPN_H__
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "../EmuStructs.h"
 

--- a/emu/cores/fmopn2612.c
+++ b/emu/cores/fmopn2612.c
@@ -140,7 +140,7 @@
 #define _USE_MATH_DEFINES
 #include <math.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "../EmuHelper.h"
 

--- a/emu/cores/gb.c
+++ b/emu/cores/gb.c
@@ -55,8 +55,8 @@ TODO:
 #include <stdlib.h>	// for rand
 #include <string.h>	// for memset
 
-#include <stdtype.h>
-#include <stdbool.h>
+#include "../../stdtype.h"
+#include "../../stdbool.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../snddef.h"

--- a/emu/cores/iremga20.c
+++ b/emu/cores/iremga20.c
@@ -47,7 +47,7 @@ Revisions:
 #include <string.h>	// for memset
 #include <stddef.h>	// for NULL
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../snddef.h"

--- a/emu/cores/k051649.c
+++ b/emu/cores/k051649.c
@@ -27,7 +27,7 @@
 #include <stdlib.h>
 #include <string.h>	// for memset
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../snddef.h"

--- a/emu/cores/k053260.c
+++ b/emu/cores/k053260.c
@@ -59,7 +59,7 @@
 #include <string.h>	// for memset
 #include <stddef.h>	// for NULL
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../snddef.h"

--- a/emu/cores/k054539.c
+++ b/emu/cores/k054539.c
@@ -17,7 +17,7 @@
 #include <stddef.h>	// for NULL
 #include <math.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../snddef.h"

--- a/emu/cores/multipcm.c
+++ b/emu/cores/multipcm.c
@@ -38,7 +38,7 @@
 #include <string.h>	// for memset
 #include <stddef.h>	// for NULL
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../snddef.h"

--- a/emu/cores/nes_apu.c
+++ b/emu/cores/nes_apu.c
@@ -50,8 +50,8 @@
 #include <string.h>	// for memset
 #include <stddef.h>	// for NULL
 
-#include <stdtype.h>
-#include <stdbool.h>
+#include "../../stdtype.h"
+#include "../../stdbool.h"
 #include "../snddef.h"
 #include "nes_apu.h"
 

--- a/emu/cores/nes_defs.h
+++ b/emu/cores/nes_defs.h
@@ -26,8 +26,8 @@
 #ifndef __NES_DEFS_H__
 #define __NES_DEFS_H__
 
-#include <stdtype.h>
-#include <stdbool.h>
+#include "../../stdtype.h"
+#include "../../stdbool.h"
 
 /* REGULAR TYPE DEFINITIONS */
 typedef INT8          int8;

--- a/emu/cores/nesintf.c
+++ b/emu/cores/nesintf.c
@@ -2,8 +2,8 @@
 #include <string.h>	// for memset
 #include <stddef.h>	// for NULL
 
-#include <stdtype.h>
-#include <stdbool.h>
+#include "../../stdtype.h"
+#include "../../stdbool.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../EmuHelper.h"

--- a/emu/cores/np_nes_apu.c
+++ b/emu/cores/np_nes_apu.c
@@ -9,8 +9,8 @@
 #include <stdlib.h>
 #include <stddef.h>	// for NULL
 
-#include <stdtype.h>
-#include <stdbool.h>
+#include "../../stdtype.h"
+#include "../../stdbool.h"
 #include "../snddef.h"
 #include "../RatioCntr.h"
 #include "np_nes_apu.h"

--- a/emu/cores/np_nes_dmc.c
+++ b/emu/cores/np_nes_dmc.c
@@ -7,8 +7,8 @@
 #include <stdlib.h>
 #include <stddef.h>	// for NULL
 
-#include <stdtype.h>
-#include <stdbool.h>
+#include "../../stdtype.h"
+#include "../../stdbool.h"
 #include "../snddef.h"
 #include "../RatioCntr.h"
 #include "np_nes_apu.h"	// for NES_APU_np_FrameSequence

--- a/emu/cores/np_nes_fds.c
+++ b/emu/cores/np_nes_fds.c
@@ -6,8 +6,8 @@
 #include <stddef.h>	// for NULL
 #include <math.h>	// for exp
 
-#include <stdtype.h>
-#include <stdbool.h>
+#include "../../stdtype.h"
+#include "../../stdbool.h"
 #include "../snddef.h"
 #include "../RatioCntr.h"
 #include "np_nes_fds.h"

--- a/emu/cores/nukedopl.c
+++ b/emu/cores/nukedopl.c
@@ -30,7 +30,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "nukedopl.h"
 #include "nukedopl_int.h"

--- a/emu/cores/nukedopl.h
+++ b/emu/cores/nukedopl.h
@@ -1,7 +1,7 @@
 #ifndef __NUKEDOPL_H__
 #define __NUKEDOPL_H__
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 
 void nukedopl3_write(void *chip, UINT8 a, UINT8 v);

--- a/emu/cores/nukedopl_int.h
+++ b/emu/cores/nukedopl_int.h
@@ -30,7 +30,7 @@
 #ifndef __NUKEDOPL_INT_H__
 #define __NUKEDOPL_INT_H__
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 
 //#define NOPL_ENABLE_WRITEBUF

--- a/emu/cores/nukedopll_int.h
+++ b/emu/cores/nukedopll_int.h
@@ -24,7 +24,7 @@
 #ifndef __NUKEDOPLL_INT_H__
 #define __NUKEDOPLL_INT_H__
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 
 #define RSM_FRAC 10

--- a/emu/cores/okiadpcm.c
+++ b/emu/cores/okiadpcm.c
@@ -12,7 +12,7 @@
 #include <stddef.h>
 #include <math.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "okiadpcm.h"
 
 

--- a/emu/cores/okim6258.c
+++ b/emu/cores/okim6258.c
@@ -18,7 +18,7 @@
 #include <stddef.h>	// for NULL
 #include <math.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "../EmuHelper.h"
 #include "../EmuCores.h"

--- a/emu/cores/okim6295.c
+++ b/emu/cores/okim6295.c
@@ -54,7 +54,7 @@
 #include <string.h>	// for memset
 #include <math.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "../EmuHelper.h"
 #include "../EmuCores.h"

--- a/emu/cores/oplintf.c
+++ b/emu/cores/oplintf.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../EmuHelper.h"

--- a/emu/cores/opnintf.c
+++ b/emu/cores/opnintf.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../SoundDevs.h"

--- a/emu/cores/pokey.c
+++ b/emu/cores/pokey.c
@@ -54,7 +54,7 @@
 #endif
 #include <stdlib.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../snddef.h"

--- a/emu/cores/pwm.c
+++ b/emu/cores/pwm.c
@@ -23,7 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "../EmuHelper.h"
 #include "../EmuCores.h"

--- a/emu/cores/qsound_ctr.c
+++ b/emu/cores/qsound_ctr.c
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 #include <string.h>	// for memset
 #include <math.h>
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../snddef.h"

--- a/emu/cores/qsound_mame.c
+++ b/emu/cores/qsound_mame.c
@@ -34,7 +34,7 @@
 #include <stddef.h>	// for NULL
 #include <math.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../snddef.h"

--- a/emu/cores/rf5c68.c
+++ b/emu/cores/rf5c68.c
@@ -8,7 +8,7 @@
 #include <string.h>	// for memset
 #include <stddef.h>	// for NULL
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"

--- a/emu/cores/saa1099_mame.c
+++ b/emu/cores/saa1099_mame.c
@@ -73,7 +73,7 @@
 #include <stdlib.h>
 #include <string.h>	// for memset
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"

--- a/emu/cores/saa1099_vb.c
+++ b/emu/cores/saa1099_vb.c
@@ -20,7 +20,7 @@
 #include <stdlib.h>
 #include <string.h>	// for memset
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"

--- a/emu/cores/scd_pcm.c
+++ b/emu/cores/scd_pcm.c
@@ -12,7 +12,7 @@
 #include <string.h>
 #include <stdlib.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"

--- a/emu/cores/scsp.c
+++ b/emu/cores/scsp.c
@@ -37,7 +37,7 @@
 #include <stdlib.h>
 #include <string.h>	// for memset
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../snddef.h"

--- a/emu/cores/scspdsp.c
+++ b/emu/cores/scspdsp.c
@@ -2,7 +2,7 @@
 // copyright-holders:ElSemi, R. Belmont
 #include <string.h> // for memset
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "scspdsp.h"
 
 static UINT16 PACK(INT32 val)

--- a/emu/cores/segapcm.c
+++ b/emu/cores/segapcm.c
@@ -8,7 +8,7 @@
 #include <string.h>	// for memset
 #include <stdio.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../snddef.h"

--- a/emu/cores/segapcm.h
+++ b/emu/cores/segapcm.h
@@ -1,7 +1,7 @@
 #ifndef __SEGAPCM_H__
 #define __SEGAPCM_H__
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../EmuStructs.h"
 
 // cfg.bnkshift: ROM bank shift

--- a/emu/cores/sn76489.c
+++ b/emu/cores/sn76489.c
@@ -24,7 +24,7 @@
 #include <float.h>	// for FLT_MIN
 #include <string.h>	// for memcpy
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"

--- a/emu/cores/sn76489_private.h
+++ b/emu/cores/sn76489_private.h
@@ -1,7 +1,7 @@
 #ifndef __SN76489_PRIVATE_H__
 #define __SN76489_PRIVATE_H__
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "sn764intf.h"
 

--- a/emu/cores/sn76496.c
+++ b/emu/cores/sn76496.c
@@ -142,7 +142,7 @@
 #include <string.h>	// for memset()
 #include <math.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"

--- a/emu/cores/upd7759.c
+++ b/emu/cores/upd7759.c
@@ -130,7 +130,7 @@
 #include <string.h> // for memset
 #include <stddef.h> // for NULL
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "../EmuHelper.h"
 #include "../EmuCores.h"

--- a/emu/cores/vsu.c
+++ b/emu/cores/vsu.c
@@ -18,7 +18,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../snddef.h"

--- a/emu/cores/ws_audio.c
+++ b/emu/cores/ws_audio.c
@@ -2,7 +2,7 @@
 #include <string.h>	// for memset
 #include <stddef.h>	// for NULL
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../snddef.h"

--- a/emu/cores/x1_010.c
+++ b/emu/cores/x1_010.c
@@ -56,7 +56,7 @@ Registers:
 #include <stddef.h>	// for NULL
 #include <string.h>	// for memset
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../snddef.h"

--- a/emu/cores/ym2151.c
+++ b/emu/cores/ym2151.c
@@ -35,7 +35,7 @@
 #define _USE_MATH_DEFINES
 #include <math.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../snddef.h"

--- a/emu/cores/ym2413.c
+++ b/emu/cores/ym2413.c
@@ -45,7 +45,7 @@ to do:
 #define _USE_MATH_DEFINES
 #include <math.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"

--- a/emu/cores/ym2413.h
+++ b/emu/cores/ym2413.h
@@ -2,7 +2,7 @@
 #define __YM2413_H__
 
 #include "../EmuStructs.h"
-#include <stdtype.h>
+#include "../../stdtype.h"
 
 extern DEV_DEF devDef_YM2413_MAME;
 

--- a/emu/cores/ym2612.c
+++ b/emu/cores/ym2612.c
@@ -27,7 +27,7 @@
 #define _USE_MATH_DEFINES
 #include <math.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "ym2612.h"
 #include "ym2612_int.h"

--- a/emu/cores/ym2612.h
+++ b/emu/cores/ym2612.h
@@ -1,7 +1,7 @@
 #ifndef __YM2612_H__
 #define __YM2612_H__
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 
 typedef struct ym2612__ ym2612_;
 

--- a/emu/cores/ym3438.c
+++ b/emu/cores/ym3438.c
@@ -29,7 +29,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "ym3438.h"
 #include "ym3438_int.h"

--- a/emu/cores/ym3438.h
+++ b/emu/cores/ym3438.h
@@ -1,7 +1,7 @@
 #ifndef __YM3438_H__
 #define __YM3438_H__
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 
 void nukedopn2_write(void *chip, UINT8 port, UINT8 data);

--- a/emu/cores/ym3438_int.h
+++ b/emu/cores/ym3438_int.h
@@ -30,7 +30,7 @@
 #ifndef __YM3438_INT_H__
 #define __YM3438_INT_H__
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 
 #define RSM_FRAC 10

--- a/emu/cores/ymdeltat.c
+++ b/emu/cores/ymdeltat.c
@@ -64,7 +64,7 @@
 
 #include <stdio.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "../EmuHelper.h"
 #include "ymdeltat.h"

--- a/emu/cores/ymdeltat.h
+++ b/emu/cores/ymdeltat.h
@@ -1,7 +1,7 @@
 #ifndef __YMDELTAT_H__
 #define __YMDELTAT_H__
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 
 #define YM_DELTAT_SHIFT    (16)
 

--- a/emu/cores/ymf262.c
+++ b/emu/cores/ymf262.c
@@ -64,7 +64,7 @@ differences between OPL2 and OPL3 shown in datasheets:
 #define _USE_MATH_DEFINES
 #include <math.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../snddef.h"
 #include "../EmuHelper.h"
 #include "ymf262.h"

--- a/emu/cores/ymf262.h
+++ b/emu/cores/ymf262.h
@@ -1,7 +1,7 @@
 #ifndef __YMF262_H__
 #define __YMF262_H__
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 
 typedef void (*OPL3_TIMERHANDLER)(void *param,UINT8 timer,UINT32 period);
 typedef void (*OPL3_IRQHANDLER)(void *param,UINT8 irq);

--- a/emu/cores/ymf271.c
+++ b/emu/cores/ymf271.c
@@ -31,8 +31,8 @@
 #define _USE_MATH_DEFINES
 #include <math.h>
 
-#include <stdtype.h>
-#include <stdbool.h>
+#include "../../stdtype.h"
+#include "../../stdbool.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../snddef.h"

--- a/emu/cores/ymf278b.c
+++ b/emu/cores/ymf278b.c
@@ -98,7 +98,7 @@
 #include <string.h>
 #include <math.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../snddef.h"

--- a/emu/cores/ymz280b.c
+++ b/emu/cores/ymz280b.c
@@ -38,7 +38,7 @@
 #include <stddef.h>	// for NULL
 #include <math.h>
 
-#include <stdtype.h>
+#include "../../stdtype.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../snddef.h"

--- a/emu/dac_control.c
+++ b/emu/dac_control.c
@@ -17,7 +17,7 @@
 #include <string.h>
 #include <stddef.h>	// for NULL
 
-#include <stdtype.h>
+#include "../stdtype.h"
 #include "EmuStructs.h"
 #include "snddef.h"
 #include "SoundDevs.h"

--- a/emu/dac_control.h
+++ b/emu/dac_control.h
@@ -6,7 +6,7 @@ extern "C"
 {
 #endif
 
-#include <stdtype.h>
+#include "../stdtype.h"
 #include "EmuStructs.h"
 
 void daccontrol_update(void* info, UINT32 samples, DEV_SMPL** dummy);

--- a/emu/panning.c
+++ b/emu/panning.c
@@ -8,7 +8,7 @@
 #define _USE_MATH_DEFINES
 #include <math.h>
 
-#include <stdtype.h>
+#include "../stdtype.h"
 #include "panning.h"
 
 #ifndef M_PI

--- a/emu/panning.h
+++ b/emu/panning.h
@@ -6,7 +6,7 @@ extern "C"
 {
 #endif
 
-#include <stdtype.h>
+#include "../stdtype.h"
 
 #define PANNING_BITS	16	// 16.16 fixed point
 #define PANNING_NORMAL	(1 << PANNING_BITS)

--- a/emu/snddef.h
+++ b/emu/snddef.h
@@ -1,7 +1,7 @@
 #ifndef __SNDDEF_H__
 #define __SNDDEF_H__
 
-#include <common_def.h>
+#include "../common_def.h"
 
 // DEV_SMPL is used to represent a single sample in a sound stream
 typedef INT32 DEV_SMPL;

--- a/emutest.c
+++ b/emutest.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 #include "emu/EmuStructs.h"
 #include "emu/SoundEmu.h"
 #include "emu/SoundDevs.h"

--- a/player.cpp
+++ b/player.cpp
@@ -28,7 +28,7 @@ extern "C" int __cdecl _kbhit(void);
 #define	Sleep(msec)	usleep(msec * 1000)
 #endif
 
-#include <common_def.h>
+#include "common_def.h"
 #include "utils/DataLoader.h"
 #include "utils/FileLoader.h"
 #include "utils/MemoryLoader.h"

--- a/player/dblk_compr.c
+++ b/player/dblk_compr.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <common_def.h>
+#include "../common_def.h"
 #include "dblk_compr.h"
 
 // integer types for fast integer calculation

--- a/player/dblk_compr.h
+++ b/player/dblk_compr.h
@@ -6,7 +6,7 @@ extern "C"
 {
 #endif
 
-#include <stdtype.h>
+#include "../stdtype.h"
 
 typedef struct _pcm_compression_table
 {

--- a/player/droplayer.cpp
+++ b/player/droplayer.cpp
@@ -9,11 +9,11 @@
 
 #include "../common_def.h"
 #include "droplayer.hpp"
-#include <emu/EmuStructs.h>
-#include <emu/SoundEmu.h>
-#include <emu/Resampler.h>
-#include <emu/SoundDevs.h>
-#include <emu/EmuCores.h>
+#include "../emu/EmuStructs.h"
+#include "../emu/SoundEmu.h"
+#include "../emu/Resampler.h"
+#include "../emu/SoundDevs.h"
+#include "../emu/EmuCores.h"
 #include "helper.h"
 
 

--- a/player/droplayer.cpp
+++ b/player/droplayer.cpp
@@ -7,7 +7,7 @@
 
 #define INLINE	static inline
 
-#include <common_def.h>
+#include "../common_def.h"
 #include "droplayer.hpp"
 #include <emu/EmuStructs.h>
 #include <emu/SoundEmu.h>

--- a/player/droplayer.hpp
+++ b/player/droplayer.hpp
@@ -2,8 +2,8 @@
 #define __DROPLAYER_HPP__
 
 #include "../stdtype.h"
-#include <emu/EmuStructs.h>
-#include <emu/Resampler.h>
+#include "../emu/EmuStructs.h"
+#include "../emu/Resampler.h"
 #include "helper.h"
 #include "playerbase.hpp"
 #include "../utils/DataLoader.h"

--- a/player/droplayer.hpp
+++ b/player/droplayer.hpp
@@ -1,7 +1,7 @@
 #ifndef __DROPLAYER_HPP__
 #define __DROPLAYER_HPP__
 
-#include <stdtype.h>
+#include "../stdtype.h"
 #include <emu/EmuStructs.h>
 #include <emu/Resampler.h>
 #include "helper.h"

--- a/player/helper.c
+++ b/player/helper.c
@@ -2,9 +2,9 @@
 #include <string.h>
 
 #include "../stdtype.h"
-#include <emu/EmuStructs.h>
-#include <emu/SoundEmu.h>
-#include <emu/Resampler.h>
+#include "../emu/EmuStructs.h"
+#include "../emu/SoundEmu.h"
+#include "../emu/Resampler.h"
 #include "helper.h"
 
 void SetupLinkedDevices(VGM_BASEDEV* cBaseDev, SETUPLINKDEV_CB devCfgCB, void* cbUserParam)

--- a/player/helper.c
+++ b/player/helper.c
@@ -1,7 +1,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <stdtype.h>
+#include "../stdtype.h"
 #include <emu/EmuStructs.h>
 #include <emu/SoundEmu.h>
 #include <emu/Resampler.h>

--- a/player/helper.h
+++ b/player/helper.h
@@ -7,8 +7,8 @@ extern "C"
 #endif
 
 #include "../stdtype.h"
-#include <emu/EmuStructs.h>
-#include <emu/Resampler.h>
+#include "../emu/EmuStructs.h"
+#include "../emu/Resampler.h"
 
 typedef struct _vgm_base_device VGM_BASEDEV;
 struct _vgm_base_device

--- a/player/helper.h
+++ b/player/helper.h
@@ -6,7 +6,7 @@ extern "C"
 {
 #endif
 
-#include <stdtype.h>
+#include "../stdtype.h"
 #include <emu/EmuStructs.h>
 #include <emu/Resampler.h>
 

--- a/player/playerbase.hpp
+++ b/player/playerbase.hpp
@@ -2,7 +2,7 @@
 #define __PLAYERBASE_HPP__
 
 #include "../stdtype.h"
-#include <emu/Resampler.h>
+#include "../emu/Resampler.h"
 #include "../utils/DataLoader.h"
 #include <vector>
 

--- a/player/playerbase.hpp
+++ b/player/playerbase.hpp
@@ -1,7 +1,7 @@
 #ifndef __PLAYERBASE_HPP__
 #define __PLAYERBASE_HPP__
 
-#include <stdtype.h>
+#include "../stdtype.h"
 #include <emu/Resampler.h>
 #include "../utils/DataLoader.h"
 #include <vector>

--- a/player/s98player.cpp
+++ b/player/s98player.cpp
@@ -8,7 +8,7 @@
 
 #define INLINE	static inline
 
-#include <common_def.h>
+#include "../common_def.h"
 #include "s98player.hpp"
 #include <emu/EmuStructs.h>
 #include <emu/SoundEmu.h>

--- a/player/s98player.cpp
+++ b/player/s98player.cpp
@@ -10,13 +10,13 @@
 
 #include "../common_def.h"
 #include "s98player.hpp"
-#include <emu/EmuStructs.h>
-#include <emu/SoundEmu.h>
-#include <emu/Resampler.h>
-#include <emu/SoundDevs.h>
-#include <emu/EmuCores.h>
-#include <emu/cores/sn764intf.h>	// for SN76496_CFG
-#include <emu/cores/ayintf.h>		// for AY8910_CFG
+#include "../emu/EmuStructs.h"
+#include "../emu/SoundEmu.h"
+#include "../emu/Resampler.h"
+#include "../emu/SoundDevs.h"
+#include "../emu/EmuCores.h"
+#include "../emu/cores/sn764intf.h"	// for SN76496_CFG
+#include "../emu/cores/ayintf.h"		// for AY8910_CFG
 #include "../utils/StrUtils.h"
 #include "helper.h"
 

--- a/player/s98player.hpp
+++ b/player/s98player.hpp
@@ -1,7 +1,7 @@
 #ifndef __S98PLAYER_HPP__
 #define __S98PLAYER_HPP__
 
-#include <stdtype.h>
+#include "../stdtype.h"
 #include <emu/EmuStructs.h>
 #include <emu/Resampler.h>
 #include "../utils/StrUtils.h"

--- a/player/s98player.hpp
+++ b/player/s98player.hpp
@@ -2,8 +2,8 @@
 #define __S98PLAYER_HPP__
 
 #include "../stdtype.h"
-#include <emu/EmuStructs.h>
-#include <emu/Resampler.h>
+#include "../emu/EmuStructs.h"
+#include "../emu/Resampler.h"
 #include "../utils/StrUtils.h"
 #include "helper.h"
 #include "playerbase.hpp"

--- a/player/vgmplayer.cpp
+++ b/player/vgmplayer.cpp
@@ -6,7 +6,7 @@
 
 #define INLINE	static inline
 
-#include <common_def.h>
+#include "../common_def.h"
 #include "vgmplayer.hpp"
 #include <emu/EmuStructs.h>
 #include <emu/SoundEmu.h>

--- a/player/vgmplayer.cpp
+++ b/player/vgmplayer.cpp
@@ -8,20 +8,20 @@
 
 #include "../common_def.h"
 #include "vgmplayer.hpp"
-#include <emu/EmuStructs.h>
-#include <emu/SoundEmu.h>
-#include <emu/Resampler.h>
-#include <emu/SoundDevs.h>
-#include <emu/EmuCores.h>
-#include <emu/dac_control.h>
-#include <emu/cores/sn764intf.h>	// for SN76496_CFG
-#include <emu/cores/segapcm.h>		// for SEGAPCM_CFG
-#include <emu/cores/ayintf.h>		// for AY8910_CFG
-#include <emu/cores/okim6258.h>		// for OKIM6258_CFG
-#include <emu/cores/k054539.h>
-#include <emu/cores/c140.h>
-#include <emu/cores/es5503.h>
-#include <emu/cores/es5506.h>
+#include "../emu/EmuStructs.h"
+#include "../emu/SoundEmu.h"
+#include "../emu/Resampler.h"
+#include "../emu/SoundDevs.h"
+#include "../emu/EmuCores.h"
+#include "../emu/dac_control.h"
+#include "../emu/cores/sn764intf.h"	// for SN76496_CFG
+#include "../emu/cores/segapcm.h"		// for SEGAPCM_CFG
+#include "../emu/cores/ayintf.h"		// for AY8910_CFG
+#include "../emu/cores/okim6258.h"		// for OKIM6258_CFG
+#include "../emu/cores/k054539.h"
+#include "../emu/cores/c140.h"
+#include "../emu/cores/es5503.h"
+#include "../emu/cores/es5506.h"
 
 #include "dblk_compr.h"
 #include "../utils/StrUtils.h"

--- a/player/vgmplayer.hpp
+++ b/player/vgmplayer.hpp
@@ -1,7 +1,7 @@
 #ifndef __VGMPLAYER_HPP__
 #define __VGMPLAYER_HPP__
 
-#include <stdtype.h>
+#include "../stdtype.h"
 #include <emu/EmuStructs.h>
 #include <emu/Resampler.h>
 #include "../utils/StrUtils.h"

--- a/player/vgmplayer.hpp
+++ b/player/vgmplayer.hpp
@@ -2,8 +2,8 @@
 #define __VGMPLAYER_HPP__
 
 #include "../stdtype.h"
-#include <emu/EmuStructs.h>
-#include <emu/Resampler.h>
+#include "../emu/EmuStructs.h"
+#include "../emu/Resampler.h"
 #include "../utils/StrUtils.h"
 #include "helper.h"
 #include "playerbase.hpp"

--- a/player/vgmplayer_cmdhandler.cpp
+++ b/player/vgmplayer_cmdhandler.cpp
@@ -7,9 +7,9 @@
 
 #include "../common_def.h"
 #include "vgmplayer.hpp"
-#include <emu/EmuStructs.h>
-#include <emu/dac_control.h>
-#include <emu/cores/sn764intf.h>	// for SN76496_W constants
+#include "../emu/EmuStructs.h"
+#include "../emu/dac_control.h"
+#include "../emu/cores/sn764intf.h"	// for SN76496_W constants
 
 #include "dblk_compr.h"
 #include "helper.h"

--- a/player/vgmplayer_cmdhandler.cpp
+++ b/player/vgmplayer_cmdhandler.cpp
@@ -5,7 +5,7 @@
 
 #define INLINE	static inline
 
-#include <common_def.h>
+#include "../common_def.h"
 #include "vgmplayer.hpp"
 #include <emu/EmuStructs.h>
 #include <emu/dac_control.h>

--- a/utils/DataLoader.c
+++ b/utils/DataLoader.c
@@ -1,7 +1,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <stdtype.h>
+#include "../stdtype.h"
 #include "DataLoader.h"
 
 UINT8 DataLoader_Reset(DATA_LOADER *loader)

--- a/utils/DataLoader.h
+++ b/utils/DataLoader.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-#include <stdtype.h>
+#include "../stdtype.h"
 
 typedef UINT8 (*DLOADCB_GENERIC)(void *context);
 typedef UINT32 (*DLOADCB_READ)(void *context, UINT8 *buffer, UINT32 numBytes);

--- a/utils/FileLoader.c
+++ b/utils/FileLoader.c
@@ -3,7 +3,7 @@
 #include <string.h>
 #include <zlib.h>
 
-#include <common_def.h>
+#include "../common_def.h"
 #include "FileLoader.h"
 
 enum

--- a/utils/MemoryLoader.c
+++ b/utils/MemoryLoader.c
@@ -2,7 +2,7 @@
 #include <string.h>
 #include <zlib.h>
 
-#include <common_def.h>
+#include "../common_def.h"
 #include "DataLoader.h"
 #include "MemoryLoader.h"
 

--- a/utils/MemoryLoader.h
+++ b/utils/MemoryLoader.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-#include <stdtype.h>
+#include "../stdtype.h"
 #include "DataLoader.h"
 
 DATA_LOADER *MemoryLoader_Init(const UINT8 *buffer, UINT32 length);

--- a/utils/OSMutex.h
+++ b/utils/OSMutex.h
@@ -6,7 +6,7 @@ extern "C"
 {
 #endif
 
-#include <stdtype.h>
+#include "../stdtype.h"
 
 typedef struct _os_mutex OS_MUTEX;
 

--- a/utils/OSMutex_POSIX.c
+++ b/utils/OSMutex_POSIX.c
@@ -7,7 +7,7 @@
 #include <pthread.h>
 #include <errno.h>
 
-#include <stdtype.h>
+#include "../stdtype.h"
 #include "OSMutex.h"
 
 //typedef struct _os_mutex OS_MUTEX;

--- a/utils/OSMutex_Win.c
+++ b/utils/OSMutex_Win.c
@@ -6,7 +6,7 @@
 
 #include <Windows.h>
 
-#include <stdtype.h>
+#include "../stdtype.h"
 #include "OSMutex.h"
 
 //typedef struct _os_mutex OS_MUTEX;

--- a/utils/OSSignal.h
+++ b/utils/OSSignal.h
@@ -6,7 +6,7 @@ extern "C"
 {
 #endif
 
-#include <stdtype.h>
+#include "../stdtype.h"
 
 typedef struct _os_signal OS_SIGNAL;
 

--- a/utils/OSSignal_POSIX.c
+++ b/utils/OSSignal_POSIX.c
@@ -7,7 +7,7 @@
 #include <pthread.h>
 #include <errno.h>
 
-#include <stdtype.h>
+#include "../stdtype.h"
 #include "OSSignal.h"
 
 //typedef struct _os_signal OS_SIGNAL;

--- a/utils/OSSignal_Win.c
+++ b/utils/OSSignal_Win.c
@@ -6,7 +6,7 @@
 
 #include <Windows.h>
 
-#include <stdtype.h>
+#include "../stdtype.h"
 #include "OSSignal.h"
 
 //typedef struct _os_signal OS_SIGNAL;

--- a/utils/OSThread.h
+++ b/utils/OSThread.h
@@ -6,7 +6,7 @@ extern "C"
 {
 #endif
 
-#include <stdtype.h>
+#include "../stdtype.h"
 
 typedef struct _os_thread OS_THREAD;
 typedef void (*OS_THR_FUNC)(void* args);

--- a/utils/OSThread_POSIX.c
+++ b/utils/OSThread_POSIX.c
@@ -6,7 +6,7 @@
 
 #include <pthread.h>
 
-#include <stdtype.h>
+#include "../stdtype.h"
 #include "OSThread.h"
 
 //typedef struct _os_thread OS_THREAD;

--- a/utils/OSThread_Win.c
+++ b/utils/OSThread_Win.c
@@ -6,7 +6,7 @@
 
 #include <Windows.h>
 
-#include <stdtype.h>
+#include "../stdtype.h"
 #include "OSThread.h"
 
 //typedef struct _os_thread OS_THREAD;

--- a/utils/StrUtils-CPConv_IConv.c
+++ b/utils/StrUtils-CPConv_IConv.c
@@ -13,7 +13,7 @@
 #include <iconv.h>
 #include <errno.h>
 
-#include <stdtype.h>
+#include "../stdtype.h"
 #include "StrUtils.h"
 
 //typedef struct _codepage_conversion CPCONV;

--- a/utils/StrUtils-CPConv_Win.c
+++ b/utils/StrUtils-CPConv_Win.c
@@ -17,7 +17,7 @@
 #define snprintf	_snprintf
 #endif
 
-#include <stdtype.h>
+#include "../stdtype.h"
 #include "StrUtils.h"
 
 //typedef struct _codepage_conversion CPCONV;

--- a/utils/StrUtils.h
+++ b/utils/StrUtils.h
@@ -6,7 +6,7 @@ extern "C"
 {
 #endif
 
-#include <stdtype.h>
+#include "../stdtype.h"
 
 typedef struct _codepage_conversion CPCONV;
 

--- a/vgm_dbcompr_bench.c
+++ b/vgm_dbcompr_bench.c
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <common_def.h>
+#include "common_def.h"
 #include "vgm/dblk_compr.h"
 
 

--- a/vgmtest.c
+++ b/vgmtest.c
@@ -22,7 +22,7 @@ int __cdecl _getch(void);	// from conio.h
 
 #define VGM_LONG_UPDATE	0
 
-#include <common_def.h>
+#include "common_def.h"
 #include "audio/AudioStream.h"
 #include "audio/AudioStream_SpcDrvFuns.h"
 #include "emu/EmuStructs.h"


### PR DESCRIPTION
This is mostly for Unix/Linux users wanting to install locally and use the library - when combined with #37, a library consumer can just use:

```c
#include <vgm/player/playerbase.hpp>
#include <vgm/player/vgmplayer.hpp>
(etc)
```

And not add `/usr/local/include/vgm` to their header search path for stdbool, stdtype, common_def, etc.

`stdbool.h` is a c99 header filename - I'm not sure if there's a case where c99 compilers will complain about stdbool in say, a mixed codebase. But this would prevent that kind of conflict.