### PR TITLE
fix VERSION/CMP0048 errors in CMakeLists

### DIFF
--- a/audio/CMakeLists.txt
+++ b/audio/CMakeLists.txt
@@ -1,4 +1,8 @@
 #### Audio Output Library ####
+if (POLICY CMP0048)
+	cmake_policy(SET CMP0048 NEW)
+endif ()
+
 project(vgm-audio VERSION 1.0)
 cmake_minimum_required(VERSION 2.8)
 

--- a/emu/CMakeLists.txt
+++ b/emu/CMakeLists.txt
@@ -1,4 +1,8 @@
 #### Sound Emulation Library ####
+if (POLICY CMP0048)
+	cmake_policy(SET CMP0048 NEW)
+endif ()
+
 project(vgm-emu VERSION 1.0)
 cmake_minimum_required(VERSION 2.8)
 

--- a/player/CMakeLists.txt
+++ b/player/CMakeLists.txt
@@ -1,4 +1,8 @@
 #### File Playback Library ####
+if (POLICY CMP0048)
+	cmake_policy(SET CMP0048 NEW)
+endif ()
+
 project(vgm-player VERSION 1.0)
 cmake_minimum_required(VERSION 2.8)
 

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,4 +1,8 @@
 #### miscellaneous utility functions/classes ####
+if (POLICY CMP0048)
+	cmake_policy(SET CMP0048 NEW)
+endif ()
+
 project(vgm-utils VERSION 1.0)
 cmake_minimum_required(VERSION 3.1)
 


### PR DESCRIPTION
hello! i noticed that when i attempt to run cmake in any of the project subdirectories (emu, player, audio, utils), the following error occurs:

```
CMake Error at CMakeLists.txt:2 (project):
  VERSION not allowed unless CMP0048 is set to NEW
```

it appears to have started with [this recent commit](https://github.com/ValleyBell/libvgm/commit/22b4789924840da6c24c16d5054f16a55649cc1c), which added the VERSION variables to the respective CMakeLists. 

setting the [CMP0048 policy](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html) as per the error message appears to have fixed the problem.
