### PR TITLE
build with static libstdc++ for MSYS/MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,10 @@ if(MSVC)
 		add_definitions("/D _CRT_SECURE_NO_WARNINGS")
 	endif()
 endif()
+if(MINGW)
+    set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc -static-libstdc++ -lwsock32 -lws2_32 ${CMAKE_CSS_STANDARD_LIBRARIES}")
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive")
+endif()
 
 if(CMAKE_COMPILER_IS_GNUCC)
 


### PR DESCRIPTION
Unfortunately this still doesn't create a fully statically linked binaries, thanks to dependencies on zlib and iconv. Maybe those can be replaced in the future?

    mkdir build && cd build
    cmake .. -G "MSYS Makefiles" -D AUDIODRV_LIBAO=OFF
    make -j5
    cp `which zlib1.dll` bin
    cp `which libiconv-2.dll` bin