### PR TITLE
Index through the PLR_MUTE_OPTS chnMute array for linked device.

### DIFF
--- a/player/s98player.cpp
+++ b/player/s98player.cpp
@@ -610,7 +610,7 @@ void S98Player::RefreshMuting(S98_CHIPDEV& chipDev, const PLR_MUTE_OPTS& muteOpt
 	{
 		DEV_INFO* devInf = &clDev->defInf;
 		if (devInf->dataPtr != NULL && devInf->devDef->SetMuteMask != NULL)
-			devInf->devDef->SetMuteMask(devInf->dataPtr, muteOpts.chnMute[0]);
+			devInf->devDef->SetMuteMask(devInf->dataPtr, muteOpts.chnMute[linkCntr]);
 	}
 	
 	return;

--- a/player/vgmplayer.cpp
+++ b/player/vgmplayer.cpp
@@ -594,7 +594,7 @@ void VGMPlayer::RefreshMuting(VGMPlayer::CHIP_DEVICE& chipDev, const PLR_MUTE_OP
 	{
 		DEV_INFO* devInf = &clDev->defInf;
 		if (devInf->dataPtr != NULL && devInf->devDef->SetMuteMask != NULL)
-			devInf->devDef->SetMuteMask(devInf->dataPtr, muteOpts.chnMute[0]);
+			devInf->devDef->SetMuteMask(devInf->dataPtr, muteOpts.chnMute[linkCntr]);
 	}
 	
 	return;


### PR DESCRIPTION
Currently it looks like RefreshMuting will set the same muting mask to the pair of linked devices. I think this change was what was intended.