### PR TITLE
Add option to build with static libraries for MSYS/MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,17 @@ if(MSVC)
 	endif()
 endif()
 
+if(MINGW)
+	option(LINK_STATIC_LIBS "link with static libraries" ON)
+	if(LINK_STATIC_LIBS)
+		set(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+		set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc -static-libstdc++ -lwsock32 -lws2_32 ${CMAKE_CSS_STANDARD_LIBRARIES}")
+		set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive")
+	endif()
+else()
+	option(LINK_STATIC_LIBS "build with static libraries" OFF)
+endif()
+
 if(CMAKE_COMPILER_IS_GNUCC)
 
 # assume Windows 2000 and later for GetConsoleWindow API call

--- a/audio/CMakeLists.txt
+++ b/audio/CMakeLists.txt
@@ -69,8 +69,12 @@ option(AUDIODRV_SADA "Audio Driver: SADA (Solaris Audio Device Architecture) [So
 option(AUDIODRV_ALSA "Audio Driver: ALSA (Advanced Linux Sound Architecture) [Linux]" ${ALSA_FOUND})
 option(AUDIODRV_PULSE "Audio Driver: PulseAudio [Linux]" ${PULSEAUDIO_FOUND})
 option(AUDIODRV_APPLE "Audio Driver: Core Audio [macOS]" ${ADRV_APPLE})
-option(AUDIODRV_LIBAO "Audio Driver: libao" ${LIBAO_FOUND})
-
+if(LINK_STATIC_LIBS)
+	# linking errors when using static library in MinGW
+	option(AUDIODRV_LIBAO "Audio Driver: libao" OFF)
+else()
+	option(AUDIODRV_LIBAO "Audio Driver: libao" ${LIBAO_FOUND})
+endif()
 
 if(AUDIODRV_WAVEWRITE)
 	set(AUDIO_DEFS ${AUDIO_DEFS} " AUDDRV_WAVEWRITE")


### PR DESCRIPTION
This solves the issues with the previous PR #46.

It seems like the static libao library has linking errors on my MinGW install, so I disabled it by default. I think it should be no issue to do this since there are already multiple other audio drivers usable for Windows.