### PR TITLE
strutils: use strcasecmp/strncasecmp on non-windows

### DIFF
--- a/utils/StrUtils-CPConv_IConv.c
+++ b/utils/StrUtils-CPConv_IConv.c
@@ -10,6 +10,12 @@
 #define strdup		_strdup
 #define stricmp		_stricmp
 #define strnicmp	_strnicmp
+#else
+#ifdef _POSIX_C_SOURCE
+#include <strings.h>
+#endif
+#define stricmp strcasecmp
+#define strnicmp strncasecmp
 #endif
 
 #include <iconv.h>


### PR DESCRIPTION
Have not had the opportunity to test this on OSX, but on POSIX systems the strcasecmp and strncasecmp should be used (strnicmp doesn't exist on my Linux system)