### PR TITLE
ym2612: make SLOT_SET, CHANNEL_SET, and YM_SET local

### DIFF
--- a/emu/cores/ym2612.c
+++ b/emu/cores/ym2612.c
@@ -365,6 +365,7 @@ INLINE void CSM_Key_Control(ym2612_ *YM2612)
 }
 
 
+static
 int SLOT_SET(ym2612_ *YM2612, int Adr, unsigned char data)
 {
   channel_ *CH;
@@ -527,6 +528,7 @@ int SLOT_SET(ym2612_ *YM2612, int Adr, unsigned char data)
 }
 
 
+static
 int CHANNEL_SET(ym2612_ *YM2612, int Adr, unsigned char data)
 {
   channel_ *CH;
@@ -691,6 +693,7 @@ int CHANNEL_SET(ym2612_ *YM2612, int Adr, unsigned char data)
 }
 
 
+static
 int YM_SET(ym2612_ *YM2612, int Adr, unsigned char data)
 {
   channel_ *CH;


### PR DESCRIPTION
Noticed these were exposed as global symbols, but they're not used anywhere else