### PR TITLE
add MSVC CI jobs

### DIFF
--- a/.github/workflows/GHA.yml
+++ b/.github/workflows/GHA.yml
@@ -51,8 +51,8 @@ jobs:
       if: ${{ runner.os == 'Windows' && matrix.config.compiler == 'msvc' }}
       run: |
         echo 'CMAKE_OPTS=-DUTIL_CHARCNV_ICONV=OFF -DUTIL_CHARCNV_WINAPI=ON ' \
-        '-DZLIB_LIBRARY_DEBUG=${GITHUB_WORKSPACE}/libs/lib/zdll.lib ' \
-        '-DZLIB_LIBRARY_RELEASE=${GITHUB_WORKSPACE}/libs/lib/zdll.lib' >> $GITHUB_ENV
+        '-DZLIB_LIBRARY_DEBUG=./libs/lib/zdll.lib ' \
+        '-DZLIB_LIBRARY_RELEASE=./libs/lib/zdll.lib' >> $GITHUB_ENV
 
     - name: Dependencies [macOS]
       if: runner.os == 'macOS'

--- a/.github/workflows/GHA.yml
+++ b/.github/workflows/GHA.yml
@@ -2,7 +2,7 @@ name: Build Tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, ci-testing ]
   pull_request:
     branches: [ master ]
 
@@ -15,8 +15,12 @@ jobs:
     strategy:
       matrix:
         config:
-          - { os: windows-latest, shell: "msys2 {0}", build_type: Release, extra_settings: "-G 'MSYS Makefiles'" }
-          - { os: windows-latest, shell: "msys2 {0}", build_type: Debug, extra_settings: "-G 'MSYS Makefiles'" }
+          - { os: windows-latest, shell: bash, compiler: msvc, build_type: Release, extra_settings: "-A Win32 -DUTIL_CHARCNV_ICONV=OFF -DUTIL_CHARCNV_WINAPI=ON" }
+          - { os: windows-latest, shell: bash, compiler: msvc, build_type: Debug, extra_settings: "-A Win32 -DUTIL_CHARCNV_ICONV=OFF -DUTIL_CHARCNV_WINAPI=ON" }
+          #- { os: windows-latest, shell: bash, compiler: msvc, build_type: Release, extra_settings: "-A x64 -DUTIL_CHARCNV_ICONV=OFF -DUTIL_CHARCNV_WINAPI=ON" }
+          #- { os: windows-latest, shell: bash, compiler: msvc, build_type: Debug, extra_settings: "-A x64 -DUTIL_CHARCNV_ICONV=OFF -DUTIL_CHARCNV_WINAPI=ON" }
+          - { os: windows-latest, shell: "msys2 {0}", compiler: mingw, build_type: Release, extra_settings: "-G 'MSYS Makefiles'" }
+          - { os: windows-latest, shell: "msys2 {0}", compiler: mingw, build_type: Debug, extra_settings: "-G 'MSYS Makefiles'" }
           - { os: macos-latest, shell: bash, build_type: Release }
           - { os: macos-latest, shell: bash, build_type: Debug }
           - { os: ubuntu-latest, shell: bash, build_type: Release }
@@ -32,8 +36,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Dependencies [Windows]
-      if: runner.os == 'Windows'
+    - name: Dependencies [Windows MinGW]
+      if: ${{ runner.os == 'Windows' && runner.compiler == 'mingw' }}
       uses: msys2/setup-msys2@v2
       with:
         msystem: MINGW64

--- a/.github/workflows/GHA.yml
+++ b/.github/workflows/GHA.yml
@@ -50,9 +50,9 @@ jobs:
     - name: Dependencies [Windows MSVC]
       if: ${{ runner.os == 'Windows' && matrix.config.compiler == 'msvc' }}
       run: |
-        echo 'CMAKE_OPTS=-DUTIL_CHARCNV_ICONV=OFF -DUTIL_CHARCNV_WINAPI=ON \
-        -DZLIB_LIBRARY_DEBUG=${GITHUB_WORKSPACE}/libs/lib/zdll.lib \
-        -DZLIB_LIBRARY_RELEASE=${GITHUB_WORKSPACE}/libs/lib/zdll.lib' >> $GITHUB_ENV
+        echo 'CMAKE_OPTS=-DUTIL_CHARCNV_ICONV=OFF -DUTIL_CHARCNV_WINAPI=ON ' \
+        '-DZLIB_LIBRARY_DEBUG=${GITHUB_WORKSPACE}/libs/lib/zdll.lib ' \
+        '-DZLIB_LIBRARY_RELEASE=${GITHUB_WORKSPACE}/libs/lib/zdll.lib' >> $GITHUB_ENV
 
     - name: Dependencies [macOS]
       if: runner.os == 'macOS'

--- a/.github/workflows/GHA.yml
+++ b/.github/workflows/GHA.yml
@@ -15,16 +15,16 @@ jobs:
     strategy:
       matrix:
         config:
-          - { os: windows-latest, shell: bash, compiler: msvc, build_type: Release, extra_settings: "-A Win32 -DUTIL_CHARCNV_ICONV=OFF -DUTIL_CHARCNV_WINAPI=ON" }
-          - { os: windows-latest, shell: bash, compiler: msvc, build_type: Debug, extra_settings: "-A Win32 -DUTIL_CHARCNV_ICONV=OFF -DUTIL_CHARCNV_WINAPI=ON" }
-          #- { os: windows-latest, shell: bash, compiler: msvc, build_type: Release, extra_settings: "-A x64 -DUTIL_CHARCNV_ICONV=OFF -DUTIL_CHARCNV_WINAPI=ON" }
-          #- { os: windows-latest, shell: bash, compiler: msvc, build_type: Debug, extra_settings: "-A x64 -DUTIL_CHARCNV_ICONV=OFF -DUTIL_CHARCNV_WINAPI=ON" }
+          - { os: windows-latest, shell: bash, compiler: msvc, build_type: Release, extra_settings: "-A Win32" }
+          - { os: windows-latest, shell: bash, compiler: msvc, build_type: Debug, extra_settings: "-A Win32" }
+          #- { os: windows-latest, shell: bash, compiler: msvc, build_type: Release, extra_settings: "-A x64" }
+          #- { os: windows-latest, shell: bash, compiler: msvc, build_type: Debug, extra_settings: "-A x64" }
           - { os: windows-latest, shell: "msys2 {0}", compiler: mingw, build_type: Release, extra_settings: "-G 'MSYS Makefiles'" }
           - { os: windows-latest, shell: "msys2 {0}", compiler: mingw, build_type: Debug, extra_settings: "-G 'MSYS Makefiles'" }
-          - { os: macos-latest, shell: bash, build_type: Release }
-          - { os: macos-latest, shell: bash, build_type: Debug }
-          - { os: ubuntu-latest, shell: bash, build_type: Release }
-          - { os: ubuntu-latest, shell: bash, build_type: Debug }
+#          - { os: macos-latest, shell: bash, build_type: Release }
+#          - { os: macos-latest, shell: bash, build_type: Debug }
+#          - { os: ubuntu-latest, shell: bash, build_type: Release }
+#          - { os: ubuntu-latest, shell: bash, build_type: Debug }
       fail-fast: false
 
     runs-on: ${{ matrix.config.os }}
@@ -37,7 +37,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Dependencies [Windows MinGW]
-      if: ${{ runner.os == 'Windows' && runner.compiler == 'mingw' }}
+      if: ${{ runner.os == 'Windows' && matrix.config.compiler == 'mingw' }}
       uses: msys2/setup-msys2@v2
       with:
         msystem: MINGW64
@@ -46,6 +46,13 @@ jobs:
           make mingw-w64-x86_64-cmake
           mingw-w64-x86_64-toolchain
           mingw-w64-x86_64-zlib mingw-w64-x86_64-libiconv
+
+    - name: Dependencies [Windows MSVC]
+      if: ${{ runner.os == 'Windows' && matrix.config.compiler == 'msvc' }}
+      run: |
+        export CMAKE_OPTS="-DUTIL_CHARCNV_ICONV=OFF -DUTIL_CHARCNV_WINAPI=ON \
+        ZLIB_LIBRARY_DEBUG=${GITHUB_WORKSPACE}/libs/lib/zdll.lib \
+        ZLIB_LIBRARY_RELEASE=${GITHUB_WORKSPACE}/libs/lib/zdll.lib"
 
     - name: Dependencies [macOS]
       if: runner.os == 'macOS'
@@ -70,6 +77,7 @@ jobs:
           -B ${GITHUB_WORKSPACE}/build \
           -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install \
           -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} \
+          ${CMAKE_OPTS} \
           -DBUILD_TESTS=ON \
 
     - name: Build

--- a/.github/workflows/GHA.yml
+++ b/.github/workflows/GHA.yml
@@ -2,7 +2,7 @@ name: Build Tests
 
 on:
   push:
-    branches: [ master, ci-testing ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 
@@ -19,12 +19,12 @@ jobs:
           - { os: windows-latest, shell: bash, compiler: msvc, build_type: Debug, extra_settings: "-A Win32" }
           #- { os: windows-latest, shell: bash, compiler: msvc, build_type: Release, extra_settings: "-A x64" }
           #- { os: windows-latest, shell: bash, compiler: msvc, build_type: Debug, extra_settings: "-A x64" }
-#OK          - { os: windows-latest, shell: "msys2 {0}", compiler: mingw, build_type: Release, extra_settings: "-G 'MSYS Makefiles'" }
-#OK          - { os: windows-latest, shell: "msys2 {0}", compiler: mingw, build_type: Debug, extra_settings: "-G 'MSYS Makefiles'" }
-#          - { os: macos-latest, shell: bash, build_type: Release }
-#          - { os: macos-latest, shell: bash, build_type: Debug }
-#          - { os: ubuntu-latest, shell: bash, build_type: Release }
-#          - { os: ubuntu-latest, shell: bash, build_type: Debug }
+          - { os: windows-latest, shell: "msys2 {0}", compiler: mingw, build_type: Release, extra_settings: "-G 'MSYS Makefiles'" }
+          - { os: windows-latest, shell: "msys2 {0}", compiler: mingw, build_type: Debug, extra_settings: "-G 'MSYS Makefiles'" }
+          - { os: macos-latest, shell: bash, build_type: Release }
+          - { os: macos-latest, shell: bash, build_type: Debug }
+          - { os: ubuntu-latest, shell: bash, build_type: Release }
+          - { os: ubuntu-latest, shell: bash, build_type: Debug }
       fail-fast: false
 
     runs-on: ${{ matrix.config.os }}

--- a/.github/workflows/GHA.yml
+++ b/.github/workflows/GHA.yml
@@ -50,9 +50,9 @@ jobs:
     - name: Dependencies [Windows MSVC]
       if: ${{ runner.os == 'Windows' && matrix.config.compiler == 'msvc' }}
       run: |
-        export CMAKE_OPTS="-DUTIL_CHARCNV_ICONV=OFF -DUTIL_CHARCNV_WINAPI=ON \
+        echo "CMAKE_OPTS=-DUTIL_CHARCNV_ICONV=OFF -DUTIL_CHARCNV_WINAPI=ON \
         ZLIB_LIBRARY_DEBUG=${GITHUB_WORKSPACE}/libs/lib/zdll.lib \
-        ZLIB_LIBRARY_RELEASE=${GITHUB_WORKSPACE}/libs/lib/zdll.lib"
+        ZLIB_LIBRARY_RELEASE=${GITHUB_WORKSPACE}/libs/lib/zdll.lib" >> $GITHUB_ENV
 
     - name: Dependencies [macOS]
       if: runner.os == 'macOS'

--- a/.github/workflows/GHA.yml
+++ b/.github/workflows/GHA.yml
@@ -50,9 +50,13 @@ jobs:
     - name: Dependencies [Windows MSVC]
       if: ${{ runner.os == 'Windows' && matrix.config.compiler == 'msvc' }}
       run: |
-        echo 'CMAKE_OPTS=-DUTIL_CHARCNV_ICONV=OFF -DUTIL_CHARCNV_WINAPI=ON ' \
-        '-DZLIB_LIBRARY_DEBUG=./libs/lib/zdll.lib ' \
-        '-DZLIB_LIBRARY_RELEASE=./libs/lib/zdll.lib' >> $GITHUB_ENV
+        # avoid linker errors by enforcing WinAPI (instead of libiconv)
+        # and zdll.lib (DLL instead of static)
+        # The libraries that are shipped with libvgm were built with VC6 and VC2010
+        # and don't work with VC2015 and higher.
+        echo "CMAKE_OPTS=-DUTIL_CHARCNV_ICONV=OFF -DUTIL_CHARCNV_WINAPI=ON " \
+        "-DZLIB_LIBRARY_DEBUG=${GITHUB_WORKSPACE}/libs/lib/zdll.lib " \
+        "-DZLIB_LIBRARY_RELEASE=${GITHUB_WORKSPACE}/libs/lib/zdll.lib" >> $GITHUB_ENV
 
     - name: Dependencies [macOS]
       if: runner.os == 'macOS'
@@ -91,6 +95,7 @@ jobs:
       run: |
         cmake \
           --install ${GITHUB_WORKSPACE}/build \
+          --config ${{ matrix.config.build_type }}
 
     - name: Check
       run: |

--- a/.github/workflows/GHA.yml
+++ b/.github/workflows/GHA.yml
@@ -19,8 +19,8 @@ jobs:
           - { os: windows-latest, shell: bash, compiler: msvc, build_type: Debug, extra_settings: "-A Win32" }
           #- { os: windows-latest, shell: bash, compiler: msvc, build_type: Release, extra_settings: "-A x64" }
           #- { os: windows-latest, shell: bash, compiler: msvc, build_type: Debug, extra_settings: "-A x64" }
-          - { os: windows-latest, shell: "msys2 {0}", compiler: mingw, build_type: Release, extra_settings: "-G 'MSYS Makefiles'" }
-          - { os: windows-latest, shell: "msys2 {0}", compiler: mingw, build_type: Debug, extra_settings: "-G 'MSYS Makefiles'" }
+#OK          - { os: windows-latest, shell: "msys2 {0}", compiler: mingw, build_type: Release, extra_settings: "-G 'MSYS Makefiles'" }
+#OK          - { os: windows-latest, shell: "msys2 {0}", compiler: mingw, build_type: Debug, extra_settings: "-G 'MSYS Makefiles'" }
 #          - { os: macos-latest, shell: bash, build_type: Release }
 #          - { os: macos-latest, shell: bash, build_type: Debug }
 #          - { os: ubuntu-latest, shell: bash, build_type: Release }
@@ -50,9 +50,9 @@ jobs:
     - name: Dependencies [Windows MSVC]
       if: ${{ runner.os == 'Windows' && matrix.config.compiler == 'msvc' }}
       run: |
-        echo "CMAKE_OPTS=-DUTIL_CHARCNV_ICONV=OFF -DUTIL_CHARCNV_WINAPI=ON \
-        ZLIB_LIBRARY_DEBUG=${GITHUB_WORKSPACE}/libs/lib/zdll.lib \
-        ZLIB_LIBRARY_RELEASE=${GITHUB_WORKSPACE}/libs/lib/zdll.lib" >> $GITHUB_ENV
+        echo 'CMAKE_OPTS=-DUTIL_CHARCNV_ICONV=OFF -DUTIL_CHARCNV_WINAPI=ON \
+        -DZLIB_LIBRARY_DEBUG=${GITHUB_WORKSPACE}/libs/lib/zdll.lib \
+        -DZLIB_LIBRARY_RELEASE=${GITHUB_WORKSPACE}/libs/lib/zdll.lib' >> $GITHUB_ENV
 
     - name: Dependencies [macOS]
       if: runner.os == 'macOS'


### PR DESCRIPTION
A Visual Studio build is unfortunately a bit more complicated.

The repo currently ships with zlib and iconv builds done using MSVC 6 or 2010.  
There was a ABI break between VC 2013 and 2015 that prevents all of the static libraries from working with VC2015 and higher.  
DLLs (e.g. zdll.lib) work fine though.

There is currently no MSVC 64-bit build, because all included 64-bit libraries are static builds, which of course don't work with VC2019.