### PR TITLE
Fix missing logging header installation

### DIFF
--- a/emu/CMakeLists.txt
+++ b/emu/CMakeLists.txt
@@ -257,6 +257,7 @@ set(EMU_HEADERS
 	SoundDevs.h
 	EmuCores.h
 	Resampler.h
+	logging.h
 	dac_control.h
 )
 set(EMU_CORE_HEADERS)


### PR DESCRIPTION
The new header hasn't been added to the installed headers of the emu CMakeLists.txt. Without this, vgmplay-libvgm build errors out:
```
In file included from /build/source/playctrl.cpp:35:
/nix/store/wlaysm4d7zym0z9alr98q5mxj1zp6i4z-libvgm-unstable-2021-11-26-dev/include/vgm/player/droplayer.hpp:10:10: fatal error: ../emu/logging.h: No such file or directory
   10 | #include "../emu/logging.h"
      |          ^~~~~~~~~~~~~~~~~~
compilation terminated.
In file included from /build/source/mediainfo.cpp:14:
/nix/store/wlaysm4d7zym0z9alr98q5mxj1zp6i4z-libvgm-unstable-2021-11-26-dev/include/vgm/player/droplayer.hpp:10:10: fatal error: ../emu/logging.h: No such file or directory
   10 | #include "../emu/logging.h"
      |          ^~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/vgmplay.dir/build.make:146: CMakeFiles/vgmplay.dir/playctrl.cpp.o] Error 1
```