### PR TITLE
Don't call DataLoader_CancelLoading before DataLoader_Deinit in examples

### DIFF
--- a/player.cpp
+++ b/player.cpp
@@ -166,7 +166,6 @@ int main(int argc, char* argv[])
 	retVal = DataLoader_Load(dLoad);
 	if (retVal)
 	{
-		DataLoader_CancelLoading(dLoad);
 		DataLoader_Deinit(dLoad);
 		fprintf(stderr, "Error 0x%02X loading file!\n", retVal);
 		continue;
@@ -174,7 +173,6 @@ int main(int argc, char* argv[])
 	retVal = mainPlr.LoadFile(dLoad);
 	if (retVal)
 	{
-		DataLoader_CancelLoading(dLoad);
 		DataLoader_Deinit(dLoad);
 		fprintf(stderr, "Error 0x%02X loading file!\n", retVal);
 		continue;

--- a/vgm2wav.cpp
+++ b/vgm2wav.cpp
@@ -263,7 +263,6 @@ int main(int argc, const char *argv[]) {
     /* attempt to load 256 bytes, bail if not possible */
     DataLoader_SetPreloadBytes(loader,0x100);
     if(DataLoader_Load(loader)) {
-        DataLoader_CancelLoading(loader);
         fprintf(stderr,"failed to load DataLoader\n");
         DataLoader_Deinit(loader);
         return 1;


### PR DESCRIPTION
`DataLoader_Deinit` now calls `DataLoader_Reset`, which calls `DataLoader_CancelLoading`. So calling `DataLoader_CancelLoading` before `DataLoader_Deinit` is redundant. So remove the call to `DataLoader_CancelLoading` in the example apps, to simplify the code.

(Hopefully this change is correct.)