### PR TITLE
VGMPlayer: scan v1.00/v1.01 files for FM clock used

### DIFF
--- a/player/vgmplayer.hpp
+++ b/player/vgmplayer.hpp
@@ -224,6 +224,8 @@ protected:
 	UINT8 SeekToTick(UINT32 tick);
 	UINT8 SeekToFilePos(UINT32 pos);
 	void ParseFile(UINT32 ticks);
+
+	void ParseFileForFMClocks();
 	
 	// --- VGM command functions ---
 	void Cmd_invalid(void);
@@ -363,6 +365,11 @@ protected:
 	UINT32 _ym2612pcm_bnkPos;
 	UINT8 _rf5cBank[2][2];	// [0 RF5C68 / 1 RF5C164][chipID]
 	QSOUND_WORK _qsWork[2];
+
+	UINT8 _v101Fix;	// enable hack/fix for v1.00/v1.01 VGMs with FM clock
+	UINT32 _v101ym2413clock;
+	UINT32 _v101ym2612clock;
+	UINT32 _v101ym2151clock;
 };
 
 #endif	// __VGMPLAYER_HPP__


### PR DESCRIPTION
Fixes several old dumps. Hopefully works properly for YM2151 dumps as well.

Fixes #88 