### PR TITLE
Fix OSThread_GetID on Darwin

### DIFF
--- a/utils/OSThread_POSIX.c
+++ b/utils/OSThread_POSIX.c
@@ -85,7 +85,13 @@ void OSThread_Cancel(OS_THREAD* thr)
 
 UINT64 OSThread_GetID(const OS_THREAD* thr)
 {
+#ifdef __APPLE__
+	UINT64 idNum;
+	pthread_threadid_np (thr->id, &idNum);
+	return idNum;
+#else
 	return thr->id;
+#endif
 }
 
 void* OSThread_GetHandle(OS_THREAD* thr)


### PR DESCRIPTION
> ```
> utils/OSThread_POSIX.c:88:9: warning: incompatible pointer to integer conversion returning 'const pthread_t' (aka 'struct _opaque_pthread_t *const') from a function with result type 'UINT64' (aka 'unsigned long long') [-Wint-conversion]
> ```

`pthread_t` on macOS is more than just an unsigned long int typedef, properly getting a numerical id requires the use of a non-portable function.