### PR TITLE
YMF278B: Fix aliasing in high pitched notes.

### DIFF
--- a/emu/cores/ymf278b.c
+++ b/emu/cores/ymf278b.c
@@ -177,7 +177,6 @@ typedef struct
 					// invariant: step == calcStep(OCT, FN)
 	UINT32 stepptr;	// fixed-point pointer into the sample
 	UINT16 pos;
-	INT16 sample1, sample2;
 
 	INT16 env_vol;
 
@@ -461,7 +460,7 @@ static void ymf278b_slot_reset(YMF278BSlot* slot)
 	slot->state = EG_OFF;
 
 	// not strictly needed, but avoid UMR on savestate
-	slot->pos = slot->sample1 = slot->sample2 = 0;
+	slot->pos = 0;
 }
 
 INLINE UINT8 ymf278b_slot_compute_rate(YMF278BSlot* slot, int val)
@@ -698,7 +697,7 @@ static void ymf278b_advance(YMF278BChip* chip)
 	}
 }
 
-INLINE INT16 ymf278b_getSample(YMF278BChip* chip, YMF278BSlot* op)
+INLINE INT16 ymf278b_getSample(YMF278BChip* chip, YMF278BSlot* slot, UINT16 pos)
 {
 	// TODO How does this behave when R#2 bit 0 = 1?
 	//      As-if read returns 0xff? (Like for CPU memory reads.) Or is
@@ -706,23 +705,23 @@ INLINE INT16 ymf278b_getSample(YMF278BChip* chip, YMF278BSlot* op)
 	INT16 sample;
 	UINT32 addr;
 	
-	switch (op->bits)
+	switch (slot->bits)
 	{
 	case 0:
 		// 8 bit
-		sample = ymf278b_readMem(chip, op->startaddr + op->pos) << 8;
+		sample = ymf278b_readMem(chip, slot->startaddr + pos) << 8;
 		break;
 	case 1:
 		// 12 bit
-		addr = op->startaddr + ((op->pos / 2) * 3);
-		if (op->pos & 1)
+		addr = slot->startaddr + ((pos / 2) * 3);
+		if (pos & 1)
 			sample = (ymf278b_readMem(chip, addr + 2) << 8) | ((ymf278b_readMem(chip, addr + 1) & 0xF0) << 0);
 		else
 			sample = (ymf278b_readMem(chip, addr + 0) << 8) | ((ymf278b_readMem(chip, addr + 1) & 0x0F) << 4);
 		break;
 	case 2:
 		// 16 bit
-		addr = op->startaddr + (op->pos * 2);
+		addr = slot->startaddr + (pos * 2);
 		sample = (ymf278b_readMem(chip, addr + 0) << 8) | ymf278b_readMem(chip, addr + 1);
 		break;
 	default:
@@ -731,6 +730,17 @@ INLINE INT16 ymf278b_getSample(YMF278BChip* chip, YMF278BSlot* op)
 		break;
 	}
 	return sample;
+}
+
+INLINE INT16 ymf278b_nextPos(YMF278BSlot* slot, UINT16 pos, UINT16 step)
+{
+	// If there is a 4-sample loop and you advance 12 samples per step,
+	// it may exceed the end offset.
+	// This is abused by the "Lizard Star" song to generate noise at 0:52. -Valley Bell
+	pos += step;
+	if ((UINT32)pos + slot->endaddr >= 0x10000)	// check position >= (negated) end address
+		pos = pos + slot->endaddr + slot->loopaddr;	// This is how the actual chip does it.
+	return pos;
 }
 
 static int ymf278b_anyActive(YMF278BChip* chip)
@@ -785,8 +795,8 @@ static void ymf278b_pcm_update(void *info, UINT32 samples, DEV_SMPL** outputs)
 				continue;
 			}
 
-			sample = (sl->sample1 * (0x10000 - sl->stepptr) +
-			          sl->sample2 * sl->stepptr) >> 16;
+			sample = (ymf278b_getSample(chip, sl, sl->pos) * (0x10000 - sl->stepptr) +
+			          ymf278b_getSample(chip, sl, ymf278b_nextPos(sl, sl->pos, 1)) * sl->stepptr) >> 16;
 			
 			// TL levels are 00..FF internally (TL register value 7F is mapped to TL level FF)
 			// Envelope levels have 4x the resolution (000..3FF)
@@ -820,17 +830,10 @@ static void ymf278b_pcm_update(void *info, UINT32 samples, DEV_SMPL** outputs)
 			     : sl->step;
 			sl->stepptr += step;
 
-			// If there is a 4-sample loop and you advance 12 samples per step,
-			// it may exceed the end offset.
-			// This is abused by the "Lizard Star" song to generate noise at 0:52. -Valley Bell
 			if (sl->stepptr >= 0x10000)
 			{
-				sl->sample1 = sl->sample2;
-				sl->sample2 = ymf278b_getSample(chip, sl);
-				sl->pos += (sl->stepptr >> 16);
+				sl->pos = ymf278b_nextPos(sl, sl->pos, sl->stepptr >> 16);
 				sl->stepptr &= 0xFFFF;
-				if ((UINT32)sl->pos + sl->endaddr >= 0x10000)	// check position >= (negated) end address
-					sl->pos = sl->pos + sl->endaddr + sl->loopaddr;	// This is how the actual chip does it.
 			}
 		}
 		ymf278b_advance(chip);
@@ -854,9 +857,6 @@ INLINE void ymf278b_keyOnHelper(YMF278BChip* chip, YMF278BSlot* slot)
 	}
 	slot->stepptr = 0;
 	slot->pos = 0;
-	slot->sample1 = ymf278b_getSample(chip, slot);
-	slot->pos = 1;
-	slot->sample2 = ymf278b_getSample(chip, slot);
 }
 
 static void ymf278b_A_w(YMF278BChip *chip, UINT8 reg, UINT8 data)


### PR DESCRIPTION
In afded2e the position increment and loop check was changed to reproduce the
noise effect in Omega’s Lizard Star track, however in the process this also
changed which samples were read in to interpolate between.

The interpolation should always be between two consecutive samples, however
after the prior change they would be several samples apart when the increment
is greater than 1. This generates an incorrectly interpolated sample value.

The issue is fixed by retrieving the two samples directly in the location where
they are interpolated, and the double buffer (sample1, sample2) is removed.

See https://github.com/openMSX/openMSX/issues/1400