### PR TITLE
YMF278: Restart sample position when wave changes during release.

### DIFF
--- a/emu/cores/ymf278b.c
+++ b/emu/cores/ymf278b.c
@@ -946,8 +946,12 @@ static void ymf278b_C_w(YMF278BChip* chip, UINT8 reg, UINT8 data)
 				ymf278b_C_w(chip, 8 + snum + (i - 2) * 24, buf[i]);
 			}
 			
-			if (slot->keyon)
+			if (slot->keyon) {
 				ymf278b_keyOnHelper(chip, slot);
+			} else {
+				slot->stepptr = 0;
+				slot->pos = 0;
+			}
 			break;
 		case 1:
 			slot->wave = (slot->wave & 0xFF) | ((data & 0x1) << 8);


### PR DESCRIPTION
I verified on real OPL4 that changing wave during key on indeed retriggers the EG, and doing so during key off does not. The EG state is unaffected other than the new wave table parameters being applied to it. The sample position does get reset though, so it plays from the beginning.

See https://github.com/openMSX/openMSX/pull/1420 for test case.