### PR TITLE
Fix some memory errors

### DIFF
--- a/player/s98player.cpp
+++ b/player/s98player.cpp
@@ -92,6 +92,7 @@ INLINE void SaveDeviceConfig(std::vector<UINT8>& dst, const void* srcData, size_
 }
 
 S98Player::S98Player() :
+	_fileHdr(),
 	_filePos(0),
 	_fileTick(0),
 	_playTick(0),


### PR DESCRIPTION
1. Make sure `S98Player::_fileHdr` is zero-initialized by the constructor.
2. Handle resampling of blocks larger than the initial sample buffer size by allocating a larger buffer when necessary. Fixes #12.