### PR TITLE
VGMPlayer::ParseFileForFMClocks: handle command 0x63 correctly

### DIFF
--- a/player/vgmplayer.cpp
+++ b/player/vgmplayer.cpp
@@ -1875,32 +1875,23 @@ void VGMPlayer::ParseFileForFMClocks()
 
 		switch (curCmd)
 		{
-		case 0x66: // end
+		case 0x66: // end of command data
 			return;
-
-		case 0x50: // PSG
-		case 0x63: // byte delay
-			filePos += 2;
-			break;
-
-		case 0x61: // delay
-			filePos += 3;
-			break;
 
 		case 0x67: // data block
 			filePos += 7 + ReadLE32(&_fileData[filePos + 3]);
 			break;
 
-		case 0x51: // YM2413
+		case 0x51: // YM2413 register write
 			return;
 
-		case 0x52: // YM2612 port 0
-		case 0x53: // YM2612 port 1
+		case 0x52: // YM2612 register write, port 0
+		case 0x53: // YM2612 register write, port 1
 			_v101ym2612clock = _v101ym2413clock;
 			_v101ym2413clock = 0;
 			return;
 
-		case 0x54: // YM2151
+		case 0x54: // YM2151 register write
 			_v101ym2151clock = _v101ym2413clock;
 			_v101ym2413clock = 0;
 			return;


### PR DESCRIPTION
0x63 was treated as having a 1-byte parameter but it actually has no parameters. This could advance the file position to a command parameter rather than a command. This could trigger the `return` in the `default` case. Therefore, a VGM 1.01 file that uses the YM2612 or the YM2151 (instead of the YM2413) could be rendered as silence because the YM2612/YM2151 clock rate could remain set to 0.

To fix this, we can just remove the cases for commands 0x50, 0x61, and 0x63 because the `default` case handles them just fine.