### PR TITLE
audemutest: Update broken Resampler mode

### DIFF
--- a/audemutest.c
+++ b/audemutest.c
@@ -193,15 +193,15 @@ int main(int argc, char* argv[])
 	okiDefInf.devDef->Reset(okiDefInf.dataPtr);
 	opllDefInf.devDef->Reset(opllDefInf.dataPtr);
 	
-	Resmpl_SetVals(&snResmpl, 0xFF, 0xC0, opts->sampleRate);
+	Resmpl_SetVals(&snResmpl, RSMODE_LINEAR, 0xC0, opts->sampleRate);
 	Resmpl_DevConnect(&snResmpl, &snDefInf);
 	Resmpl_Init(&snResmpl);
 	
-	Resmpl_SetVals(&okiResmpl, 0xFF, 0x100, opts->sampleRate);
+	Resmpl_SetVals(&okiResmpl, RSMODE_LINEAR, 0x100, opts->sampleRate);
 	Resmpl_DevConnect(&okiResmpl, &okiDefInf);
 	Resmpl_Init(&okiResmpl);
 	
-	Resmpl_SetVals(&opllResmpl, 0xFF, 0x100, opts->sampleRate);
+	Resmpl_SetVals(&opllResmpl, RSMODE_LINEAR, 0x100, opts->sampleRate);
 	Resmpl_DevConnect(&opllResmpl, &opllDefInf);
 	Resmpl_Init(&opllResmpl);
 	canRender = true;


### PR DESCRIPTION
Following up on our chat on IRC about audemutest. Thanks for the help!

audemutest hadn't been updated with a working resampler mode since the breaking change in 77c34eb8cc96eaf44f8f4125a89356f6d5ffc76a that made `0xFF` invalid.
Updated and working value for mode taken from here: https://github.com/ValleyBell/libvgm/blob/master/player/vgmplayer.cpp#L1599

This test worked on an out-of-date fork of libvgm, so I tested every commit since then until it broke again.

Commit:
- fix resampleMode in Resmpl_SetVals() for breaking change in 77c34eb8cc96eaf44f8f4125a89356f6d5ffc76a