### PR TITLE
rename stdbool substitute

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,7 +219,7 @@ endif(BUILD_VGM2WAV)
 
 set(COMMON_HEADERS
 	common_def.h
-	stdbool.h
+	_stdbool.h
 	stdtype.h
 )
 

--- a/_stdbool.h
+++ b/_stdbool.h
@@ -2,7 +2,18 @@
 #ifndef __CST_STDBOOL_H__
 #define __CST_STDBOOL_H__
 
-#ifndef __cplusplus	// C++ already has the bool-type
+#undef __HAVE_STDBOOL_H__
+#if defined __has_include
+#if __has_include(<stdbool.h>)
+#define __HAVE_STDBOOL_H__ 1
+#endif
+#elif defined(_MSC_VER) && _MSC_VER >= 1900
+#define __HAVE_STDBOOL_H__ 1
+#endif
+
+#if defined(__HAVE_STDBOOL_H__)
+#include <stdbool.h>
+#elif !defined(__cplusplus) // C++ already has the bool-type
 
 // the MS VC++ 6 compiler uses a one-byte-type (unsigned char, to be exact), so I'll reproduce this here
 typedef unsigned char	bool;

--- a/audio/AudioStream.c
+++ b/audio/AudioStream.c
@@ -5,7 +5,7 @@
 //#include <string.h>	// for memset
 
 #include "../stdtype.h"
-#include "../stdbool.h"
+#include "../_stdbool.h"
 
 #include "AudioStream.h"
 #include "../utils/OSMutex.h"

--- a/common_def.h
+++ b/common_def.h
@@ -2,7 +2,7 @@
 #define __COMMON_DEF_H__
 
 #include "stdtype.h"
-#include "stdbool.h"
+#include "_stdbool.h"
 
 #ifndef INLINE
 #if defined(_MSC_VER)

--- a/emu/cores/gb.c
+++ b/emu/cores/gb.c
@@ -56,7 +56,7 @@ TODO:
 #include <string.h>	// for memset
 
 #include "../../stdtype.h"
-#include "../../stdbool.h"
+#include "../../_stdbool.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../snddef.h"

--- a/emu/cores/mikey.c
+++ b/emu/cores/mikey.c
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 
 #include "../../stdtype.h"
-#include "../../stdbool.h"
+#include "../../_stdbool.h"
 #include "emutypes.h"
 #include "../snddef.h"
 #include "../EmuStructs.h"

--- a/emu/cores/nes_apu.c
+++ b/emu/cores/nes_apu.c
@@ -43,7 +43,7 @@
 #include <stddef.h>	// for NULL
 
 #include "../../stdtype.h"
-#include "../../stdbool.h"
+#include "../../_stdbool.h"
 #include "../../common_def.h"
 #include "../snddef.h"
 #include "../panning.h"

--- a/emu/cores/nes_defs.h
+++ b/emu/cores/nes_defs.h
@@ -23,7 +23,7 @@
 #define __NES_DEFS_H__
 
 #include "../../stdtype.h"
-#include "../../stdbool.h"
+#include "../../_stdbool.h"
 
 /* REGULAR TYPE DEFINITIONS */
 typedef INT8          int8;

--- a/emu/cores/nesintf.c
+++ b/emu/cores/nesintf.c
@@ -3,7 +3,7 @@
 #include <stddef.h>	// for NULL
 
 #include "../../stdtype.h"
-#include "../../stdbool.h"
+#include "../../_stdbool.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../EmuHelper.h"

--- a/emu/cores/np_nes_apu.c
+++ b/emu/cores/np_nes_apu.c
@@ -10,7 +10,7 @@
 #include <stddef.h>	// for NULL
 
 #include "../../stdtype.h"
-#include "../../stdbool.h"
+#include "../../_stdbool.h"
 #include "../snddef.h"
 #include "../RatioCntr.h"
 #include "np_nes_apu.h"

--- a/emu/cores/np_nes_dmc.c
+++ b/emu/cores/np_nes_dmc.c
@@ -8,7 +8,7 @@
 #include <stddef.h>	// for NULL
 
 #include "../../stdtype.h"
-#include "../../stdbool.h"
+#include "../../_stdbool.h"
 #include "../snddef.h"
 #include "../RatioCntr.h"
 #include "np_nes_apu.h"	// for NES_APU_np_FrameSequence

--- a/emu/cores/np_nes_fds.c
+++ b/emu/cores/np_nes_fds.c
@@ -7,7 +7,7 @@
 #include <math.h>	// for exp
 
 #include "../../stdtype.h"
-#include "../../stdbool.h"
+#include "../../_stdbool.h"
 #include "../snddef.h"
 #include "../RatioCntr.h"
 #include "np_nes_fds.h"

--- a/emu/cores/ymf271.c
+++ b/emu/cores/ymf271.c
@@ -29,7 +29,7 @@
 #include <math.h>
 
 #include "../../stdtype.h"
-#include "../../stdbool.h"
+#include "../../_stdbool.h"
 #include "../EmuStructs.h"
 #include "../EmuCores.h"
 #include "../snddef.h"

--- a/libVgmTest.vcxproj
+++ b/libVgmTest.vcxproj
@@ -166,7 +166,7 @@
     <ClInclude Include="player\playerbase.hpp" />
     <ClInclude Include="player\s98player.hpp" />
     <ClInclude Include="player\vgmplayer.hpp" />
-    <ClInclude Include="stdbool.h" />
+    <ClInclude Include="_stdbool.h" />
     <ClInclude Include="stdtype.h" />
     <ClInclude Include="utils\StrUtils.h" />
   </ItemGroup>

--- a/libVgmTest.vcxproj.filters
+++ b/libVgmTest.vcxproj.filters
@@ -18,7 +18,7 @@
     <ClInclude Include="common_def.h">
       <Filter>Headerdateien</Filter>
     </ClInclude>
-    <ClInclude Include="stdbool.h">
+    <ClInclude Include="_stdbool.h">
       <Filter>Headerdateien</Filter>
     </ClInclude>
     <ClInclude Include="stdtype.h">


### PR DESCRIPTION
also change it so it will import some known system headers where possible, such as GNU C / clang, or MSVC 2015+

This should fix compilation on Fedora 42 beta, where bool is apparently a native type even in the default C standard. Rename the substitute header, or else `<stdbool.h>` will just wrap around on itself.