### PR TITLE
Fix reversed bounds check in Cmd_PcmRamWrite

### DIFF
--- a/player/vgmplayer_cmdhandler.cpp
+++ b/player/vgmplayer_cmdhandler.cpp
@@ -821,7 +821,7 @@ void VGMPlayer::Cmd_PcmRamWrite(void)
 	const UINT8* ROMData = &_pcmBank[dbType].data[dbPos];
 	if (! dataLen)
 		dataLen += 0x01000000;
-	if (_pcmBank[dbType].data.size() - dbPos > dataLen)
+	if (dataLen > _pcmBank[dbType].data.size() - dbPos)
 		return;	// just outright ignore writes that would go out-of-bounds
 	
 	if (chipType == 0x14)	// NES APU


### PR DESCRIPTION
Fixes a backwards bounds check in `VGMPlayer::Cmd_PcmRamWrite` introduced in 460e894 that rejects all valid PCM RAM writes, breaking e.g. sega cd playback.
https://github.com/ValleyBell/libvgm/blob/460e8949dd53221bd1d9d53fb906030948f495d7/player/vgmplayer_cmdhandler.cpp#L824