### PR TITLE
VSU: fix modmask triggering for every channel

### DIFF
--- a/emu/cores/vsu.c
+++ b/emu/cores/vsu.c
@@ -304,7 +304,10 @@ static void VSU_Write(void* info, UINT16 A, UINT8 V)
 				chip->Frequency[ch] |= V << 0;
 				chip->EffFreq[ch] &= 0xFF00;
 				chip->EffFreq[ch] |= V << 0;
-				chip->ModLock = 1;
+				if (ch == 4)
+				{
+					chip->ModLock = 1;
+				}
 				break;
 
 			case 0x3:
@@ -312,7 +315,10 @@ static void VSU_Write(void* info, UINT16 A, UINT8 V)
 				chip->Frequency[ch] |= (V & 0x7) << 8;
 				chip->EffFreq[ch] &= 0x00FF;
 				chip->EffFreq[ch] |= (V & 0x7) << 8;
-				chip->ModLock = 2;
+				if (ch == 4)
+				{
+					chip->ModLock = 2;
+				}
 				break;
 
 			case 0x4:


### PR DESCRIPTION
This pull request fixes a bug I introduced in #142. I implemented a hardware bug where writing to S5FQL or S5FQH locks the corresponding byte of the frequency value. In my initial implementation, however, this triggered when writing the FQL or FQH registers of any channel, not just channel 5.

Reproducing sample with before/after/hardware (may not be pleasant to listen to):
[repro.zip](https://github.com/user-attachments/files/25659040/repro.zip)
