### PR TITLE
Detect when OPL4 playback needs YRW801 ROM

### DIFF
--- a/player.cpp
+++ b/player.cpp
@@ -1117,6 +1117,8 @@ static UINT8 FilePlayCallback(PlayerBase* player, void* userParam, UINT8 evtType
 static DATA_LOADER* RequestFileCallback(void* userParam, PlayerBase* player, const char* fileName)
 {
 	DATA_LOADER* dLoad = FileLoader_Init(fileName);
+	if (dLoad == NULL)
+		return NULL;
 	UINT8 retVal = DataLoader_Load(dLoad);
 	if (! retVal)
 		return dLoad;

--- a/player/vgmplayer.cpp
+++ b/player/vgmplayer.cpp
@@ -161,6 +161,7 @@ VGMPlayer::VGMPlayer() :
 
 	_lastTsMult = 0;
 	_lastTsDiv = 0;
+	_opl4YRW801Req = 0x00;
 	
 	for (optChip = 0x00; optChip < 0x100; optChip ++)
 	{
@@ -366,6 +367,10 @@ UINT8 VGMPlayer::ParseHeader(void)
 		}
 	}
 	
+	_opl4YRW801Req = 0x00;
+	if (GetChipCount(0x0D))	// YMF278B / OPL4
+		ParseFileForOPL4ROMRequirement();
+	
 	return 0x00;
 }
 
@@ -501,6 +506,7 @@ UINT8 VGMPlayer::UnloadFile(void)
 	_fileData = NULL;
 	_fileHdr.fileVer = 0xFFFFFFFF;
 	_fileHdr.dataOfs = 0x00;
+	_opl4YRW801Req = 0x00;
 	_devNames.clear();
 	_devices.clear();
 	_devCfgs.clear();
@@ -1531,7 +1537,8 @@ void VGMPlayer::InitDevices(void)
 			SndEmu_GetDeviceFunc(devInf->devDef, RWF_MEMORY | RWF_WRITE, DEVRW_BLOCK, 0x524F, (void**)&chipDev.romWrite);
 			SndEmu_GetDeviceFunc(devInf->devDef, RWF_MEMORY | RWF_WRITE, DEVRW_MEMSIZE, 0x5241, (void**)&chipDev.romSizeB);
 			SndEmu_GetDeviceFunc(devInf->devDef, RWF_MEMORY | RWF_WRITE, DEVRW_BLOCK, 0x5241, (void**)&chipDev.romWriteB);
-			LoadOPL4ROM(&chipDev);
+			if (_opl4YRW801Req & (1 << chipID))
+				LoadOPL4ROM(&chipDev);
 			break;
 		case DEVID_32X_PWM:
 			retVal = SndEmu_Start2(chipType, devCfg, devInf, _userDevList, _devStartOpts);
@@ -1783,20 +1790,129 @@ VGMPlayer::CHIP_DEVICE* VGMPlayer::GetDevicePtr(UINT8 chipType, UINT8 chipID)
 	return &_devices[devID];
 }
 
+void VGMPlayer::ParseFileForOPL4ROMRequirement(void)
+{
+	UINT32 filePos = _fileHdr.dataOfs;
+	UINT8 yrwUse = 0x00;
+	UINT8 fileRom = 0x00;
+	UINT8 waveTblHdr[2] = {0x00, 0x00};
+	UINT16 slotWave[2][24];
+	UINT8 stopScan = 0x00;
+	memset(slotWave, 0x00, sizeof(slotWave));
+	
+	while(filePos < _fileHdr.dataEnd && ! stopScan)
+	{
+		UINT8 curCmd = _fileData[filePos];
+		
+		switch(curCmd)
+		{
+		case 0x66:	// end of command data
+			stopScan = 0x01;
+			break;
+		case 0x67:	// data block
+			if (filePos + 0x07 > _fileHdr.dataEnd)
+			{
+				stopScan = 0x01;
+				break;
+			}
+			{
+				UINT8 dblkType = _fileData[filePos + 0x02];
+				UINT32 dblkLenRaw = ReadLE32(&_fileData[filePos + 0x03]);
+				UINT32 dblkLen = dblkLenRaw & 0x7FFFFFFF;
+				if (dblkType == 0x84)	// YMF278B ROM
+					fileRom |= 1 << (dblkLenRaw >> 31);
+				if (dblkLen > _fileHdr.dataEnd - filePos - 0x07)
+				{
+					stopScan = 0x01;
+					break;
+				}
+				filePos += 0x07 + dblkLen;
+			}
+			break;
+		case 0xD0:	// YMF278B register write
+			if (filePos + _CMD_INFO[curCmd].cmdLen > _fileHdr.dataEnd)
+			{
+				stopScan = 0x01;
+				break;
+			}
+			{
+				UINT8 chipID = (_fileData[filePos + 0x01] & 0x80) >> 7;
+				UINT8 port = _fileData[filePos + 0x01] & 0x7F;
+				UINT8 reg = _fileData[filePos + 0x02];
+				UINT8 data = _fileData[filePos + 0x03];
+				
+				if (port == 0x02)
+				{
+					if (reg == 0x02)
+					{
+						waveTblHdr[chipID] = (data >> 2) & 0x07;
+					}
+					else if (reg >= 0x08 && reg <= 0xF7)
+					{
+						UINT8 slot = (reg - 0x08) % 24;
+						UINT8 regGrp = (reg - 0x08) / 24;
+						
+						if (regGrp == 0x00)
+						{
+							slotWave[chipID][slot] = (slotWave[chipID][slot] & 0x100) | data;
+							if (slotWave[chipID][slot] < 384 || ! waveTblHdr[chipID])
+								yrwUse |= 1 << chipID;
+						}
+						else if (regGrp == 0x01)
+						{
+							slotWave[chipID][slot] = (slotWave[chipID][slot] & 0x0FF) | ((data & 0x01) << 8);
+						}
+						else if (regGrp == 0x04 && (data & 0x80))
+						{
+							if (slotWave[chipID][slot] < 384 || ! waveTblHdr[chipID])
+								yrwUse |= 1 << chipID;
+						}
+					}
+				}
+				filePos += _CMD_INFO[curCmd].cmdLen;
+			}
+			break;
+		default:
+			if (_CMD_INFO[curCmd].cmdLen == 0)
+			{
+				stopScan = 0x01;
+				break;
+			}
+			if (filePos + _CMD_INFO[curCmd].cmdLen > _fileHdr.dataEnd)
+			{
+				stopScan = 0x01;
+				break;
+			}
+			filePos += _CMD_INFO[curCmd].cmdLen;
+			break;
+		}
+	}
+	
+	_opl4YRW801Req = yrwUse & ~fileRom;
+	return;
+}
+
 void VGMPlayer::LoadOPL4ROM(CHIP_DEVICE* chipDev)
 {
 	static const char* romFile = "yrw801.rom";
 	
 	if (chipDev->romWrite == NULL)
 		return;
+	emu_logf(&_logger, PLRLOG_DEBUG, "OPL4 requires external sample ROM %s.\n", romFile);
 	
 	if (_yrwRom.empty())
 	{
 		if (_fileReqCbFunc == NULL)
+		{
+			emu_logf(&_logger, PLRLOG_WARN, "No file request callback available for %s.\n", romFile);
 			return;
+		}
 		DATA_LOADER* romDLoad = _fileReqCbFunc(_fileReqCbParam, this, romFile);
 		if (romDLoad == NULL)
+		{
+			emu_logf(&_logger, PLRLOG_WARN, "Couldn't load %s.\n", romFile);
 			return;
+		}
 		DataLoader_ReadAll(romDLoad);
 		
 		UINT32 yrwSize = DataLoader_GetSize(romDLoad);
@@ -1806,7 +1922,10 @@ void VGMPlayer::LoadOPL4ROM(CHIP_DEVICE* chipDev)
 		DataLoader_Deinit(romDLoad);
 	}
 	if (_yrwRom.empty())
+	{
+		emu_logf(&_logger, PLRLOG_WARN, "Couldn't load %s.\n", romFile);
 		return;
+	}
 	
 	if (chipDev->romSize != NULL)
 		chipDev->romSize(chipDev->base.defInf.dataPtr, (UINT32)_yrwRom.size());

--- a/player/vgmplayer.hpp
+++ b/player/vgmplayer.hpp
@@ -217,6 +217,7 @@ protected:
 	
 	static void DeviceLinkCallback(void* userParam, VGM_BASEDEV* cDev, DEVLINK_INFO* dLink);
 	CHIP_DEVICE* GetDevicePtr(UINT8 chipType, UINT8 chipID);
+	void ParseFileForOPL4ROMRequirement(void);
 	void LoadOPL4ROM(CHIP_DEVICE* chipDev);
 	
 	UINT8 SeekToTick(UINT32 tick);
@@ -366,6 +367,7 @@ protected:
 	PCM_COMPR_TBL _pcmComprTbl;
 	
 	UINT8 _p2612Fix;	// enable hack/fix for Project2612 VGMs
+	UINT8 _opl4YRW801Req;	// bit mask for YMF278B chips that need the YRW801 sample ROM
 	UINT32 _ym2612pcm_bnkPos;
 	UINT8 _rf5cBank[2][2];	// [0 RF5C68 / 1 RF5C164][chipID]
 	QSOUND_WORK _qsWork[2];

--- a/vgm2wav.cpp
+++ b/vgm2wav.cpp
@@ -89,6 +89,9 @@ scan_uint(const char *str);
 static const char *
 fmt_time(double ts);
 
+static DATA_LOADER*
+request_file_callback(void* userParam, PlayerBase* player, const char* fileName);
+
 static const char *
 extensible_guid_trailer= "\x00\x00\x00\x00\x10\x00\x80\x00\x00\xAA\x00\x38\x9B\x71";
 
@@ -229,6 +232,7 @@ int main(int argc, const char *argv[]) {
     player.RegisterPlayerEngine(new S98Player);
     player.RegisterPlayerEngine(new DROPlayer);
     player.RegisterPlayerEngine(new GYMPlayer);
+    player.SetFileReqCallback(request_file_callback, NULL);
 
     /* setup the player's output parameters and allocate internal buffers */
     if (player.SetOutputSettings(sample_rate, 2, bit_depth, BUFFER_LEN)) {
@@ -474,6 +478,22 @@ fmt_time(double sec) {
     snprintf(&ts[strlen(ts)],7,"%02u.%03u",i_sec, (unsigned int)((sec - (unsigned int)sec) * 1000));
 
     return (const char *)ts;
+}
+
+static DATA_LOADER*
+request_file_callback(void* userParam, PlayerBase* player, const char* fileName) {
+    DATA_LOADER* loader = FileLoader_Init(fileName);
+    UINT8 retVal;
+
+    if (loader == NULL) {
+        return NULL;
+    }
+    retVal = DataLoader_Load(loader);
+    if (! retVal) {
+        return loader;
+    }
+    DataLoader_Deinit(loader);
+    return NULL;
 }
 
 static void FCC2STR(char *str, UINT32 fcc) {


### PR DESCRIPTION
Avoid requesting yrw801.rom for YMF278B/OPL4 VGMs that only use the FM part or rely solely on embedded custom wave data. Add a pre-scan of OPL4 commands that tracks wave-table usage, distinguishing custom sample tables from YRW/GM wave entries.

Also make the sample tools report and request missing external ROM files more clearly.